### PR TITLE
Add adaptive JND go/no-go experiment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store

--- a/experiments/jnd-go-nogo.html
+++ b/experiments/jnd-go-nogo.html
@@ -1,0 +1,525 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Just Noticeable Difference Go/No-Go</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://unpkg.com/jspsych@7.3.3/css/jspsych.css" />
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+      --bg: radial-gradient(circle at top, #0f172a 0%, #111827 60%, #020617 100%);
+      --card-bg: rgba(15, 23, 42, 0.9);
+      --accent: #38bdf8;
+      --stage-size: min(68vw, 68vh);
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--bg);
+      color: #e2e8f0;
+      padding: clamp(16px, 4vw, 48px);
+    }
+
+    #jspsych-target {
+      width: min(96vw, 860px);
+      background: rgba(15, 23, 42, 0.82);
+      backdrop-filter: blur(18px);
+      border-radius: 32px;
+      box-shadow: 0 24px 60px rgba(2, 6, 23, 0.55);
+      padding: clamp(24px, 5vw, 56px);
+    }
+
+    .jspsych-display-element {
+      font-size: clamp(18px, 3vw, 22px);
+      line-height: 1.7;
+    }
+
+    .jspsych-btn {
+      font-size: clamp(1rem, 2.6vw, 1.15rem);
+      padding: clamp(12px, 3vw, 16px) clamp(24px, 5vw, 36px);
+      border-radius: 999px;
+      border: none;
+      background: linear-gradient(135deg, var(--accent), #2563eb);
+      color: white;
+      font-weight: 600;
+      box-shadow: inset 0 -2px 0 rgba(15, 23, 42, 0.25);
+      transition: transform 160ms ease, box-shadow 160ms ease;
+      touch-action: manipulation;
+    }
+
+    .jspsych-btn:active {
+      transform: translateY(2px);
+      box-shadow: inset 0 2px 0 rgba(15, 23, 42, 0.35);
+    }
+
+    .stage {
+      position: relative;
+      width: var(--stage-size);
+      height: var(--stage-size);
+      margin: 0 auto;
+      background: radial-gradient(circle at top, rgba(15, 23, 42, 0.95) 0%, rgba(2, 6, 23, 0.88) 80%);
+      border-radius: clamp(24px, 6vw, 36px);
+      box-shadow: inset 0 0 0 2px rgba(148, 163, 184, 0.08), 0 24px 60px rgba(2, 6, 23, 0.6);
+      overflow: hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .dot {
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      border-radius: 999px;
+      background: #f8fafc;
+      box-shadow: 0 0 20px rgba(248, 250, 252, 0.65);
+      transform: translate(-50%, -50%);
+      will-change: transform;
+    }
+
+    .fixation {
+      font-size: clamp(36px, 7vw, 64px);
+      font-weight: 600;
+      color: rgba(241, 245, 249, 0.85);
+      text-shadow: 0 8px 30px rgba(15, 23, 42, 0.7);
+    }
+
+    .response-text {
+      font-size: clamp(18px, 3.2vw, 24px);
+      color: rgba(226, 232, 240, 0.94);
+      text-align: center;
+      padding: 24px;
+    }
+
+    .trial-progress {
+      font-size: clamp(14px, 2.5vw, 16px);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: rgba(148, 163, 184, 0.8);
+      text-align: center;
+      margin-bottom: 16px;
+    }
+
+    @media (max-width: 600px) {
+      #jspsych-target {
+        padding: clamp(20px, 6vw, 40px);
+      }
+
+      .stage {
+        border-radius: clamp(20px, 8vw, 32px);
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="jspsych-target"></div>
+
+  <script src="https://unpkg.com/jspsych@7.3.3/dist/jspsych.js"></script>
+  <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.2"></script>
+  <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.2"></script>
+  <script src="https://unpkg.com/@jspsych/plugin-call-function@1.1.2"></script>
+  <script src="https://unpkg.com/jsquest-plus@2.1.0/dist/jsQuestPlus.js"></script>
+
+  <script>
+    const jsPsych = initJsPsych({
+      display_element: 'jspsych-target',
+      show_progress_bar: true,
+      auto_update_progress_bar: false
+    });
+
+    const timeline = [];
+
+    const TARGET_ACCURACY = 0.7;
+    const GO_PROBABILITY = 1 / 3;
+    const TOTAL_TRIALS = 90;
+    const FIRST_STIM_DURATION = 33;
+    const SECOND_STIM_DURATION = 33;
+    const RESPONSE_WINDOW = 1400;
+
+    const stageSide = Math.min(window.innerWidth, window.innerHeight) * 0.7;
+    document.documentElement.style.setProperty('--stage-size', `${Math.round(stageSide)}px`);
+    const stageCenter = stageSide / 2;
+    const stagePadding = Math.max(28, stageSide * 0.06);
+    const maxRadius = Math.max(90, stageCenter - stagePadding);
+    const minRadius = Math.max(36, maxRadius * 0.28);
+    const minDiameter = Math.max(18, stageSide * 0.08);
+    const maxDiameter = Math.max(minDiameter + 16, stageSide * 0.32);
+
+    function clamp(value, min, max) {
+      return Math.min(max, Math.max(min, value));
+    }
+
+    function randomBetween(min, max) {
+      if (max <= min) {
+        return min;
+      }
+      return min + Math.random() * (max - min);
+    }
+
+    function degToRad(deg) {
+      return (deg * Math.PI) / 180;
+    }
+
+    function wrapAngle(theta) {
+      const tau = Math.PI * 2;
+      return ((theta % tau) + tau) % tau;
+    }
+
+    function polarToCartesian(cx, cy, radius, theta) {
+      return {
+        x: cx + radius * Math.cos(theta),
+        y: cy + radius * Math.sin(theta)
+      };
+    }
+
+    function createRange(start, end, step) {
+      const output = [];
+      if (end < start) {
+        output.push(parseFloat(start.toFixed(3)));
+        return output;
+      }
+      for (let value = start; value <= end + 1e-6; value += step) {
+        output.push(parseFloat(value.toFixed(3)));
+      }
+      return output;
+    }
+
+    const thetaSamples = createRange(4, 72, 2);
+    const radiusMaxShift = Math.max(6, Math.min(90, Math.floor(maxRadius - minRadius - 6)));
+    const radiusSamples = createRange(6, radiusMaxShift, 2);
+    const diameterMaxShift = Math.max(4, Math.min(60, Math.floor(maxDiameter - minDiameter - 4)));
+    const diameterSamples = createRange(4, diameterMaxShift, 2);
+    const slopeSamples = createRange(2, 5, 0.5);
+    const guessRate = [0.01];
+    const lapseRate = [0.05];
+
+    function buildQuest(stimSamples) {
+      return new jsQuestPlus({
+        psych_func: [
+          (stim, threshold, slope, guess, lapse) => jsQuestPlus.weibull(stim, threshold, slope, guess, lapse),
+          (stim, threshold, slope, guess, lapse) => 1 - jsQuestPlus.weibull(stim, threshold, slope, guess, lapse)
+        ],
+        stim_samples: [stimSamples],
+        psych_samples: [stimSamples, slopeSamples, guessRate, lapseRate]
+      });
+    }
+
+    const thetaQuest = buildQuest(thetaSamples);
+    const radiusQuest = buildQuest(radiusSamples);
+    const diameterQuest = buildQuest(diameterSamples);
+
+    function chooseStimulus(quest, samples) {
+      let chosen = quest.getStimParams();
+      try {
+        const estimates = quest.getEstimates('mode');
+        if (Array.isArray(estimates) && estimates.length >= 4) {
+          let best = chosen;
+          let bestDiff = Infinity;
+          for (const value of samples) {
+            const prob = jsQuestPlus.weibull(value, estimates[0], estimates[1], estimates[2], estimates[3]);
+            const diff = Math.abs(prob - TARGET_ACCURACY);
+            if (diff < bestDiff) {
+              bestDiff = diff;
+              best = value;
+            }
+          }
+          chosen = best;
+        }
+      } catch (error) {
+        console.warn('Quest estimate unavailable', error);
+      }
+      return chosen;
+    }
+
+    function stageHTML(content = '') {
+      return `<div class="stage">${content}</div>`;
+    }
+
+    function dotHTML(x, y, diameter) {
+      return `<div class="dot" style="left:${x}px; top:${y}px; width:${diameter}px; height:${diameter}px;"></div>`;
+    }
+
+    let trialState = {};
+
+    const instructions = {
+      type: jsPsychHtmlButtonResponse,
+      stimulus: `
+        <h1 style="margin-top:0">Just Noticeable Difference (Go/No-Go)</h1>
+        <p>
+          A white dot will flash twice. The first flash always marks the reference position and size.
+          After a brief random delay (50–1000 ms) the dot reappears.
+        </p>
+        <p>
+          On most trials the dot is identical (<strong>no-go</strong>). About one third of the time the
+          dot shifts slightly in angle, distance from the centre, or diameter (<strong>go</strong> trials).
+        </p>
+        <ul>
+          <li>Press the spacebar or tap anywhere inside the display <strong>if you notice a change</strong>.</li>
+          <li>If the dot looks identical, do nothing.</li>
+        </ul>
+        <p>
+          The stimulus differences adapt during the experiment to maintain roughly 70% accuracy on go trials using the jsQuestPlus staircase.
+        </p>
+        <p>Find a comfortable viewing distance and keep your finger near the screen or the spacebar.</p>
+      `,
+      choices: ['Begin']
+    };
+
+    timeline.push(instructions);
+
+    function createTrial(index) {
+      const setup = {
+        type: jsPsychCallFunction,
+        func: () => {
+          jsPsych.setProgressBar(index / TOTAL_TRIALS);
+          trialState = {
+            index: index + 1,
+            isGo: Math.random() < GO_PROBABILITY,
+            isi: jsPsych.randomization.randomInt(50, 1000),
+            changeType: 'none',
+            questStimValue: null,
+            questRef: null,
+            deltaTheta: 0,
+            deltaRadius: 0,
+            deltaDiameter: 0
+          };
+
+          let baseTheta = Math.random() * Math.PI * 2;
+          let baseRadius = randomBetween(minRadius, maxRadius);
+          let baseDiameter = randomBetween(minDiameter, maxDiameter);
+          let secondTheta = baseTheta;
+          let secondRadius = baseRadius;
+          let secondDiameter = baseDiameter;
+
+          if (trialState.isGo) {
+            const changeOptions = ['theta', 'radius', 'diameter'];
+            const selected = jsPsych.randomization.sampleWithoutReplacement(changeOptions, 1)[0];
+            trialState.changeType = selected;
+
+            if (selected === 'theta') {
+              const stim = chooseStimulus(thetaQuest, thetaSamples);
+              trialState.questStimValue = stim;
+              trialState.questRef = thetaQuest;
+              trialState.deltaTheta = stim;
+              const direction = jsPsych.randomization.sampleWithoutReplacement([-1, 1], 1)[0];
+              secondTheta = wrapAngle(baseTheta + direction * degToRad(stim));
+            } else if (selected === 'radius') {
+              const stim = chooseStimulus(radiusQuest, radiusSamples);
+              const directions = [];
+              if (maxRadius - stim >= minRadius) directions.push(1);
+              if (minRadius + stim <= maxRadius) directions.push(-1);
+              if (directions.length > 0) {
+                const direction = jsPsych.randomization.sampleWithoutReplacement(directions, 1)[0];
+                if (direction === 1) {
+                  baseRadius = randomBetween(minRadius, maxRadius - stim);
+                  secondRadius = baseRadius + stim;
+                } else {
+                  baseRadius = randomBetween(minRadius + stim, maxRadius);
+                  secondRadius = baseRadius - stim;
+                }
+                trialState.deltaRadius = stim;
+                trialState.questStimValue = stim;
+                trialState.questRef = radiusQuest;
+              }
+            } else if (selected === 'diameter') {
+              const stim = chooseStimulus(diameterQuest, diameterSamples);
+              const directions = [];
+              if (maxDiameter - stim >= minDiameter) directions.push(1);
+              if (minDiameter + stim <= maxDiameter) directions.push(-1);
+              if (directions.length > 0) {
+                const direction = jsPsych.randomization.sampleWithoutReplacement(directions, 1)[0];
+                if (direction === 1) {
+                  baseDiameter = randomBetween(minDiameter, maxDiameter - stim);
+                  secondDiameter = baseDiameter + stim;
+                } else {
+                  baseDiameter = randomBetween(minDiameter + stim, maxDiameter);
+                  secondDiameter = baseDiameter - stim;
+                }
+                trialState.deltaDiameter = stim;
+                trialState.questStimValue = stim;
+                trialState.questRef = diameterQuest;
+              }
+            }
+          }
+
+          const firstCoords = polarToCartesian(stageCenter, stageCenter, baseRadius, baseTheta);
+          const secondCoords = polarToCartesian(stageCenter, stageCenter, secondRadius, secondTheta);
+
+          trialState.baseTheta = baseTheta;
+          trialState.baseRadius = baseRadius;
+          trialState.baseDiameter = baseDiameter;
+          trialState.secondTheta = secondTheta;
+          trialState.secondRadius = secondRadius;
+          trialState.secondDiameter = secondDiameter;
+          trialState.firstX = firstCoords.x;
+          trialState.firstY = firstCoords.y;
+          trialState.secondX = secondCoords.x;
+          trialState.secondY = secondCoords.y;
+        }
+      };
+
+      const fixation = {
+        type: jsPsychHtmlKeyboardResponse,
+        stimulus: () => stageHTML('<div class="fixation">+</div>'),
+        choices: 'NO_KEYS',
+        trial_duration: 350,
+        data: { stage: 'fixation' }
+      };
+
+      const firstStim = {
+        type: jsPsychHtmlKeyboardResponse,
+        stimulus: () => stageHTML(dotHTML(trialState.firstX, trialState.firstY, trialState.baseDiameter)),
+        choices: 'NO_KEYS',
+        trial_duration: FIRST_STIM_DURATION,
+        data: { stage: 'stimulus_1', trial_index: index + 1 }
+      };
+
+      const isi = {
+        type: jsPsychHtmlKeyboardResponse,
+        stimulus: () => stageHTML(),
+        choices: 'NO_KEYS',
+        trial_duration: trialState.isi,
+        data: { stage: 'isi' }
+      };
+
+      const secondStim = {
+        type: jsPsychHtmlKeyboardResponse,
+        stimulus: () => stageHTML(dotHTML(trialState.secondX, trialState.secondY, trialState.secondDiameter)),
+        choices: 'NO_KEYS',
+        trial_duration: SECOND_STIM_DURATION,
+        data: { stage: 'stimulus_2', trial_index: index + 1 }
+      };
+
+      const response = {
+        type: jsPsychHtmlKeyboardResponse,
+        stimulus: () => stageHTML(`<div class="response-text">Tap anywhere or press SPACE if the second dot was different.</div>`),
+        choices: 'NO_KEYS',
+        trial_duration: RESPONSE_WINDOW,
+        data: { stage: 'response' },
+        on_load: () => {
+          const display = jsPsych.getDisplayElement();
+          const start = performance.now();
+          trialState.responseInfo = {
+            responded: false,
+            source: 'none',
+            rt: null
+          };
+
+          trialState.responseInfo.keyboardListener = jsPsych.pluginAPI.getKeyboardResponse({
+            callback_function: info => {
+              if (trialState.responseInfo.responded) return;
+              trialState.responseInfo.responded = true;
+              trialState.responseInfo.source = 'keyboard';
+              trialState.responseInfo.rt = info.rt;
+              display.removeEventListener('pointerdown', trialState.responseInfo.pointerHandler);
+              jsPsych.finishTrial({ rt: info.rt, response: 'keyboard' });
+            },
+            valid_responses: [' '],
+            rt_method: 'performance',
+            persist: false,
+            allow_held_key: false
+          });
+
+          trialState.responseInfo.pointerHandler = event => {
+            if (trialState.responseInfo.responded) return;
+            trialState.responseInfo.responded = true;
+            trialState.responseInfo.source = event.pointerType || 'pointer';
+            trialState.responseInfo.rt = performance.now() - start;
+            jsPsych.pluginAPI.cancelKeyboardResponse(trialState.responseInfo.keyboardListener);
+            display.removeEventListener('pointerdown', trialState.responseInfo.pointerHandler);
+            jsPsych.finishTrial({ rt: trialState.responseInfo.rt, response: 'pointer' });
+          };
+
+          display.addEventListener('pointerdown', trialState.responseInfo.pointerHandler);
+        },
+        on_finish: data => {
+          const display = jsPsych.getDisplayElement();
+          if (trialState.responseInfo?.pointerHandler) {
+            display.removeEventListener('pointerdown', trialState.responseInfo.pointerHandler);
+          }
+          if (trialState.responseInfo?.keyboardListener) {
+            jsPsych.pluginAPI.cancelKeyboardResponse(trialState.responseInfo.keyboardListener);
+          }
+
+          const responded = Boolean(trialState.responseInfo?.responded);
+          const rt = trialState.responseInfo?.rt ?? null;
+          const source = responded ? trialState.responseInfo?.source : 'none';
+
+          data.rt = rt;
+          data.response_source = source;
+          data.is_go = trialState.isGo;
+          data.change_type = trialState.changeType;
+          data.delta_theta = trialState.deltaTheta;
+          data.delta_radius = trialState.deltaRadius;
+          data.delta_diameter = trialState.deltaDiameter;
+          data.first_theta = trialState.baseTheta;
+          data.first_radius = trialState.baseRadius;
+          data.first_diameter = trialState.baseDiameter;
+          data.second_theta = trialState.secondTheta;
+          data.second_radius = trialState.secondRadius;
+          data.second_diameter = trialState.secondDiameter;
+          data.interstimulus = trialState.isi;
+          data.trial_number = trialState.index;
+          data.go_success = trialState.isGo ? responded : null;
+          data.correct = trialState.isGo ? responded : !responded;
+          data.quest_value = trialState.questStimValue;
+
+          if (trialState.isGo && trialState.questRef && typeof trialState.questStimValue === 'number') {
+            const responseIndex = responded ? 1 : 0;
+            try {
+              trialState.questRef.update(trialState.questStimValue, responseIndex);
+            } catch (error) {
+              console.warn('Quest update skipped', error);
+            }
+          }
+        }
+      };
+
+      return [setup, fixation, firstStim, isi, secondStim, response];
+    }
+
+    for (let i = 0; i < TOTAL_TRIALS; i++) {
+      timeline.push(...createTrial(i));
+    }
+
+    const debrief = {
+      type: jsPsychHtmlButtonResponse,
+      stimulus: () => {
+        jsPsych.setProgressBar(1);
+        const data = jsPsych.data.get();
+        const goTrials = data.filter({ stage: 'response', is_go: true });
+        const goHits = goTrials.filter({ go_success: true });
+        const noGoTrials = data.filter({ stage: 'response', is_go: false });
+        const correctNoGo = noGoTrials.filter({ correct: true });
+        const goRate = goTrials.count() ? Math.round((goHits.count() / goTrials.count()) * 100) : 0;
+        const noGoRate = noGoTrials.count() ? Math.round((correctNoGo.count() / noGoTrials.count()) * 100) : 0;
+
+        return `
+          <h2 style="margin-top:0">All done!</h2>
+          <p>You detected ${goHits.count()} of ${goTrials.count()} change trials (<strong>${goRate}%</strong> hit rate).</p>
+          <p>You withheld responses on ${correctNoGo.count()} of ${noGoTrials.count()} identical trials (<strong>${noGoRate}%</strong> correct rejections).</p>
+          <p>The adaptive staircases used jsQuestPlus to target roughly 70% success on change trials.</p>
+          <p>You can download a CSV of your responses for further analysis.</p>
+        `;
+      },
+      choices: ['Download data'],
+      on_finish: () => {
+        jsPsych.data.get().localSave('csv', 'jnd-go-nogo-data.csv');
+      }
+    };
+
+    timeline.push(debrief);
+
+    jsPsych.run(timeline);
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -161,6 +161,16 @@
     <ul class="experiment-list">
       <li class="experiment-card">
         <div>
+          <h2>JND Go/No-Go (Dot Reappearance)</h2>
+          <p>
+            Judge whether a briefly flashed dot changes when it reappears. The task adapts the dot's angle, distance, and size
+            using jsQuestPlus staircases to target 70% detection on change trials.
+          </p>
+        </div>
+        <a href="experiments/jnd-go-nogo.html">Start experiment</a>
+      </li>
+      <li class="experiment-card">
+        <div>
           <h2>Attentional Blink (Digits)</h2>
           <p>
             Observe a rapid stream of letters and digits, then report the two target numbers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "psychophysics",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "psychophysics",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "jsquest-plus": "^2.1.0"
+      }
+    },
+    "node_modules/jsquest-plus": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jsquest-plus/-/jsquest-plus-2.1.0.tgz",
+      "integrity": "sha512-r0I5OlIoFS8kjtZA8C857kUiYfO5aXGt1Bxlw2JXNxSP3Be5lq2k1hGEHeeEgSABhAm6mdoWtcAG9hiYpFqCdA==",
+      "license": "MIT",
+      "dependencies": {
+        "numeric_es6": "github:tpronk/numeric"
+      }
+    },
+    "node_modules/numeric_es6": {
+      "version": "1.2.6",
+      "resolved": "git+ssh://git@github.com/tpronk/numeric.git#c957fa2f5ca3988f084f009dd016475b149bec79"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "psychophysics",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "jsquest-plus": "^2.1.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add a just-noticeable-difference go/no-go experiment that adapts angle, radial shift, and diameter differences using jsQuestPlus staircases
- install jsquest-plus via npm and ignore node_modules
- update the landing page to link to the new experiment

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1b1c55074832188839642166e947c