### PR TITLE
Fix Attentional Blink experiment script loading

### DIFF
--- a/experiments/attentional-blink.html
+++ b/experiments/attentional-blink.html
@@ -116,13 +116,13 @@
 <body>
   <div id="jspsych-target"></div>
 
-  <script src="https://unpkg.com/jspsych@7.3.3/dist/jspsych.js"></script>
-  <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.2"></script>
-  <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.2"></script>
-  <script src="https://unpkg.com/@jspsych/plugin-survey-html-form@1.1.2"></script>
+  <script src="https://unpkg.com/jspsych@7.3.3/dist/index.browser.min.js"></script>
+  <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@2.1.0/dist/index.browser.min.js"></script>
+  <script src="https://unpkg.com/@jspsych/plugin-html-button-response@2.1.0/dist/index.browser.min.js"></script>
+  <script src="https://unpkg.com/@jspsych/plugin-survey-html-form@2.1.0/dist/index.browser.min.js"></script>
 
   <script>
-    const jsPsych = initJsPsych({
+    const jsPsych = jsPsychModule.initJsPsych({
       display_element: 'jspsych-target'
     });
 


### PR DESCRIPTION
## Summary
- load the jsPsych core and plugin bundles from their browser-friendly builds
- initialize the experiment via the jsPsychModule global so the timeline renders as expected

## Testing
- Manual inspection in browser (Playwright)

------
https://chatgpt.com/codex/tasks/task_e_68d1b2cb92f883219845765e142f7eb0