### PR TITLE
Fix ISI timing in JND Go/No-Go experiment

### DIFF
--- a/experiments/jnd-go-nogo.html
+++ b/experiments/jnd-go-nogo.html
@@ -398,7 +398,7 @@
         type: jsPsychHtmlKeyboardResponse,
         stimulus: () => stageHTML(),
         choices: 'NO_KEYS',
-        trial_duration: trialState.isi,
+        trial_duration: () => trialState.isi,
         data: { stage: 'isi' }
       };
 


### PR DESCRIPTION
## Summary
- ensure the ISI trial duration is computed at runtime so each trial uses its assigned interstimulus interval

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d218e2c6cc8321b524a4f6368f9db7