### PR TITLE
Allow continuing JND Go/No-Go sessions from uploaded JSON

### DIFF
--- a/experiments/jnd-go-nogo.html
+++ b/experiments/jnd-go-nogo.html
@@ -29,6 +29,138 @@
       padding: clamp(16px, 4vw, 48px);
     }
 
+    #pre-experiment {
+      position: fixed;
+      inset: 0;
+      background: radial-gradient(circle at top, rgba(15, 23, 42, 0.96) 0%, rgba(2, 6, 23, 0.94) 100%);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: clamp(24px, 6vw, 72px);
+      z-index: 10;
+      transition: opacity 220ms ease;
+    }
+
+    #pre-experiment.hidden {
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    .session-card {
+      width: min(92vw, 720px);
+      background: rgba(15, 23, 42, 0.85);
+      border-radius: clamp(24px, 4vw, 36px);
+      box-shadow: 0 30px 70px rgba(2, 6, 23, 0.6);
+      padding: clamp(28px, 6vw, 56px);
+      display: flex;
+      flex-direction: column;
+      gap: clamp(16px, 4vw, 28px);
+    }
+
+    .session-card h1 {
+      margin: 0;
+      font-size: clamp(1.6rem, 4vw, 2.15rem);
+    }
+
+    .session-card p {
+      margin: 0;
+      color: rgba(203, 213, 225, 0.92);
+    }
+
+    .file-picker {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 999px;
+      padding: 0;
+      overflow: hidden;
+      width: fit-content;
+      background: rgba(148, 163, 184, 0.12);
+      border: 1px solid rgba(148, 163, 184, 0.18);
+      cursor: pointer;
+    }
+
+    .file-picker input[type='file'] {
+      position: absolute;
+      inset: 0;
+      opacity: 0;
+      cursor: pointer;
+    }
+
+    .file-picker span {
+      padding: 12px 24px;
+      font-weight: 600;
+      color: #e2e8f0;
+      font-size: clamp(0.95rem, 2.4vw, 1.05rem);
+    }
+
+    .session-status {
+      margin: 0;
+      font-size: clamp(0.95rem, 2.6vw, 1.05rem);
+      color: rgba(148, 163, 184, 0.88);
+    }
+
+    .session-status[data-state='error'] {
+      color: #fca5a5;
+    }
+
+    .session-status[data-state='warning'] {
+      color: #facc15;
+    }
+
+    .session-status strong {
+      color: #f8fafc;
+    }
+
+    .session-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+
+    .session-actions .jspsych-btn:disabled {
+      opacity: 0.55;
+      cursor: not-allowed;
+    }
+
+    .psychometrics-output {
+      border-top: 1px solid rgba(148, 163, 184, 0.18);
+      padding-top: clamp(16px, 4vw, 28px);
+      display: flex;
+      flex-direction: column;
+      gap: clamp(16px, 4vw, 24px);
+    }
+
+    .psychometrics-output[hidden] {
+      display: none;
+    }
+
+    .psych-section {
+      background: rgba(15, 23, 42, 0.65);
+      border-radius: clamp(16px, 4vw, 24px);
+      padding: clamp(16px, 4vw, 24px);
+      border: 1px solid rgba(148, 163, 184, 0.18);
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .psych-section h3 {
+      margin: 0;
+      font-size: clamp(1.1rem, 3vw, 1.35rem);
+    }
+
+    .psych-section p {
+      margin: 0;
+      color: rgba(226, 232, 240, 0.82);
+    }
+
+    .psych-section canvas {
+      width: 100%;
+      min-height: 220px;
+    }
+
     #jspsych-target {
       width: min(96vw, 860px);
       background: rgba(15, 23, 42, 0.82);
@@ -110,6 +242,10 @@
     }
 
     @media (max-width: 600px) {
+      #pre-experiment {
+        padding: 20px;
+      }
+
       #jspsych-target {
         padding: clamp(20px, 6vw, 40px);
       }
@@ -121,6 +257,25 @@
   </style>
 </head>
 <body>
+  <div id="pre-experiment">
+    <div class="session-card">
+      <h1>Resume or explore your JND session</h1>
+      <p>
+        Upload the JSON file from a previous run to pick up the adaptive staircases where you left off or explore your
+        psychometric functions without running a new experiment.
+      </p>
+      <label class="file-picker">
+        <input type="file" id="session-file" accept="application/json" />
+        <span>Select JSON file</span>
+      </label>
+      <p id="session-status" class="session-status" data-state="info">No previous session loaded.</p>
+      <div class="session-actions">
+        <button id="start-experiment" class="jspsych-btn">Start experiment</button>
+        <button id="view-psychometrics" class="jspsych-btn" disabled>View my psychometrics</button>
+      </div>
+      <div id="psychometrics-output" class="psychometrics-output" hidden></div>
+    </div>
+  </div>
   <div id="jspsych-target"></div>
 
   <script src="../jspsych/dist/jspsych.js"></script>
@@ -128,6 +283,7 @@
   <script src="../jspsych/plugins/html-keyboard-response.js"></script>
   <script src="../jspsych/plugins/call-function.js"></script>
   <script src="https://unpkg.com/jsquest-plus@2.1.0/dist/jsQuestPlus.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 
   <script>
     const jsPsych = initJsPsych({
@@ -136,7 +292,12 @@
       auto_update_progress_bar: false
     });
 
-    const timeline = [];
+    const preExperimentOverlay = document.getElementById('pre-experiment');
+    const startButton = document.getElementById('start-experiment');
+    const viewButton = document.getElementById('view-psychometrics');
+    const fileInput = document.getElementById('session-file');
+    const statusEl = document.getElementById('session-status');
+    const psychOutput = document.getElementById('psychometrics-output');
 
     const TARGET_ACCURACY = 0.7;
     const GO_PROBABILITY = 1 / 3;
@@ -144,6 +305,12 @@
     const FIRST_STIM_DURATION = 33;
     const SECOND_STIM_DURATION = 33;
     const RESPONSE_WINDOW = 1400;
+
+    let uploadedDataArray = [];
+    let previousTrialCount = 0;
+    let progressBase = 0;
+    let progressTotal = TOTAL_TRIALS;
+    let psychCharts = [];
 
     const stageSide = Math.min(window.innerWidth, window.innerHeight) * 0.7;
     document.documentElement.style.setProperty('--stage-size', `${Math.round(stageSide)}px`);
@@ -156,6 +323,21 @@
 
     function clamp(value, min, max) {
       return Math.min(max, Math.max(min, value));
+    }
+
+    function setStatus(message, state = 'info') {
+      if (!statusEl) return;
+      statusEl.textContent = message;
+      statusEl.dataset.state = state;
+    }
+
+    function destroyPsychCharts() {
+      psychCharts.forEach(chart => {
+        if (chart && typeof chart.destroy === 'function') {
+          chart.destroy();
+        }
+      });
+      psychCharts = [];
     }
 
     function randomBetween(min, max) {
@@ -213,9 +395,256 @@
       });
     }
 
-    const thetaQuest = buildQuest(thetaSamples);
-    const radiusQuest = buildQuest(radiusSamples);
-    const diameterQuest = buildQuest(diameterSamples);
+    let thetaQuest = buildQuest(thetaSamples);
+    let radiusQuest = buildQuest(radiusSamples);
+    let diameterQuest = buildQuest(diameterSamples);
+
+    function resetQuests() {
+      thetaQuest = buildQuest(thetaSamples);
+      radiusQuest = buildQuest(radiusSamples);
+      diameterQuest = buildQuest(diameterSamples);
+    }
+
+    function computeEmpiricalPoints(trials, changeType) {
+      const goTrials = trials.filter(
+        trial =>
+          trial &&
+          trial.stage === 'response' &&
+          trial.is_go === true &&
+          trial.change_type === changeType &&
+          typeof trial.quest_value === 'number'
+      );
+      const grouped = new Map();
+      goTrials.forEach(trial => {
+        const intensity = Number(trial.quest_value);
+        if (!Number.isFinite(intensity)) {
+          return;
+        }
+        const key = intensity.toFixed(3);
+        if (!grouped.has(key)) {
+          grouped.set(key, { x: intensity, hits: 0, total: 0 });
+        }
+        const bucket = grouped.get(key);
+        if (trial.go_success === true) {
+          bucket.hits += 1;
+        }
+        bucket.total += 1;
+      });
+      return Array.from(grouped.values())
+        .sort((a, b) => a.x - b.x)
+        .map(bucket => ({
+          x: bucket.x,
+          y: bucket.total ? bucket.hits / bucket.total : 0,
+          hits: bucket.hits,
+          total: bucket.total
+        }));
+    }
+
+    function seedQuestsFromData(dataArray) {
+      resetQuests();
+      previousTrialCount = 0;
+      if (!Array.isArray(dataArray)) {
+        return;
+      }
+      dataArray.forEach(trial => {
+        if (!trial || trial.stage !== 'response') {
+          return;
+        }
+        const trialNumber = Number(trial.trial_number ?? trial.trialIndex ?? trial.trial_index);
+        if (Number.isFinite(trialNumber)) {
+          previousTrialCount = Math.max(previousTrialCount, trialNumber);
+        }
+        if (
+          trial.is_go !== true ||
+          typeof trial.quest_value !== 'number' ||
+          !trial.change_type ||
+          trial.change_type === 'none'
+        ) {
+          return;
+        }
+        const intensity = Number(trial.quest_value);
+        if (!Number.isFinite(intensity)) {
+          return;
+        }
+        const quest =
+          trial.change_type === 'theta'
+            ? thetaQuest
+            : trial.change_type === 'radius'
+            ? radiusQuest
+            : trial.change_type === 'diameter'
+            ? diameterQuest
+            : null;
+        if (!quest) {
+          return;
+        }
+        const responseIndex = trial.go_success === true ? 1 : 0;
+        try {
+          quest.update(intensity, responseIndex);
+        } catch (error) {
+          console.warn('Quest update skipped while seeding from previous data', error);
+        }
+      });
+    }
+
+    function renderPsychometricsFromData(dataArray) {
+      destroyPsychCharts();
+      if (!psychOutput) return;
+      psychOutput.innerHTML = '';
+      if (!Array.isArray(dataArray) || dataArray.length === 0) {
+        psychOutput.innerHTML =
+          '<p class="session-status" data-state="warning">The uploaded file does not contain any trials yet.</p>';
+        psychOutput.hidden = false;
+        return;
+      }
+      if (typeof Chart === 'undefined') {
+        psychOutput.innerHTML =
+          '<p class="session-status" data-state="error">Chart.js failed to load, so the psychometric plots are unavailable.</p>';
+        psychOutput.hidden = false;
+        return;
+      }
+      const responseTrials = dataArray.filter(trial => trial && trial.stage === 'response');
+      if (!responseTrials.length) {
+        psychOutput.innerHTML =
+          '<p class="session-status" data-state="warning">The uploaded file does not contain any response-stage trials yet.</p>';
+        psychOutput.hidden = false;
+        return;
+      }
+
+      const changeTypes = [
+        { key: 'theta', label: 'Angular shift', unit: '°', color: '#38bdf8', quest: () => thetaQuest, samples: thetaSamples },
+        { key: 'radius', label: 'Radial displacement', unit: 'px', color: '#22c55e', quest: () => radiusQuest, samples: radiusSamples },
+        { key: 'diameter', label: 'Diameter change', unit: 'px', color: '#f97316', quest: () => diameterQuest, samples: diameterSamples }
+      ];
+
+      changeTypes.forEach(info => {
+        const section = document.createElement('section');
+        section.className = 'psych-section';
+
+        const heading = document.createElement('h3');
+        heading.textContent = `${info.label} (${info.unit})`;
+        section.appendChild(heading);
+
+        const quest = info.quest();
+        let estimates = null;
+        try {
+          const questEstimates = quest.getEstimates('mode');
+          if (Array.isArray(questEstimates) && questEstimates.length >= 4) {
+            estimates = questEstimates;
+          }
+        } catch (error) {
+          console.warn('Quest estimates unavailable', error);
+        }
+
+        const summary = document.createElement('p');
+        if (estimates) {
+          summary.innerHTML = `<strong>Estimated threshold:</strong> ${estimates[0].toFixed(2)} ${info.unit} · <strong>Slope:</strong> ${estimates[1].toFixed(2)}`;
+        } else {
+          summary.textContent = 'Not enough data to estimate a psychometric function yet.';
+        }
+        section.appendChild(summary);
+
+        const canvas = document.createElement('canvas');
+        section.appendChild(canvas);
+        psychOutput.appendChild(section);
+
+        const empirical = computeEmpiricalPoints(responseTrials, info.key);
+        const datasets = [];
+
+        if (estimates) {
+          const predicted = info.samples.map(value => ({
+            x: value,
+            y: jsQuestPlus.weibull(value, estimates[0], estimates[1], estimates[2], estimates[3])
+          }));
+          datasets.push({
+            label: `${info.label} fit`,
+            data: predicted,
+            fill: false,
+            borderColor: info.color,
+            backgroundColor: info.color,
+            tension: 0.25,
+            parsing: false
+          });
+        }
+
+        if (empirical.length) {
+          datasets.push({
+            label: `${info.label} empirical`,
+            data: empirical.map(point => ({ x: point.x, y: point.y })),
+            parsing: false,
+            showLine: false,
+            backgroundColor: 'rgba(248, 250, 252, 0.85)',
+            borderColor: '#f8fafc',
+            pointRadius: 4,
+            pointHoverRadius: 6
+          });
+        }
+
+        const chart = new Chart(canvas.getContext('2d'), {
+          type: 'line',
+          data: { datasets },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+              x: {
+                title: { display: true, text: `${info.label} (${info.unit})`, color: '#cbd5f5' },
+                grid: { color: 'rgba(148, 163, 184, 0.2)' },
+                ticks: { color: '#e2e8f0' }
+              },
+              y: {
+                min: 0,
+                max: 1,
+                title: { display: true, text: 'Detection probability', color: '#cbd5f5' },
+                grid: { color: 'rgba(148, 163, 184, 0.2)' },
+                ticks: {
+                  color: '#e2e8f0',
+                  callback: value => `${Math.round(value * 100)}%`
+                }
+              }
+            },
+            plugins: {
+              legend: { labels: { color: '#e2e8f0' } },
+              tooltip: {
+                callbacks: {
+                  label(context) {
+                    const datasetLabel = context.dataset.label || '';
+                    const yValue = context.parsed.y;
+                    let base = `${datasetLabel}: ${Math.round(yValue * 100)}% at ${context.parsed.x.toFixed(2)} ${info.unit}`;
+                    if (
+                      context.dataset.label &&
+                      context.dataset.label.includes('empirical') &&
+                      typeof context.dataIndex === 'number' &&
+                      empirical[context.dataIndex]
+                    ) {
+                      const point = empirical[context.dataIndex];
+                      base += ` (${point.hits}/${point.total} detections)`;
+                    }
+                    return base;
+                  }
+                }
+              }
+            }
+          }
+        });
+
+        psychCharts.push(chart);
+      });
+
+      psychOutput.hidden = false;
+    }
+
+    function downloadBlob(content, filename, type) {
+      const blob = new Blob([content], { type });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = filename;
+      anchor.rel = 'noopener';
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+    }
 
     function chooseStimulus(quest, samples) {
       let chosen = quest.getStimParams();
@@ -260,37 +689,42 @@
 
     const instructions = {
       type: jsPsychHtmlButtonResponse,
-      stimulus: `
-        <h1 style="margin-top:0">Just Noticeable Difference (Go/No-Go)</h1>
-        <p>
-          A coloured dot will flash twice. The first (odd-index) flash always marks the reference position and size.
-          After a brief random delay (50–1000 ms) the dot reappears in the same hue for the even-index comparison dot.
-        </p>
-        <p>
-          On most trials the dot is identical (<strong>no-go</strong>). About one third of the time the
-          dot shifts slightly in angle, distance from the centre, or diameter (<strong>go</strong> trials).
-        </p>
-        <ul>
-          <li>Press the spacebar or tap anywhere inside the display <strong>if the even-index (second) dot looks different</strong>.</li>
-          <li>If the comparison dot looks identical to the reference, do nothing.</li>
-        </ul>
-        <p>
-          The stimulus differences adapt during the experiment to maintain roughly 70% accuracy on go trials using the jsQuestPlus staircase.
-        </p>
-        <p>Find a comfortable viewing distance and keep your finger near the screen or the spacebar.</p>
-      `,
+      stimulus: () => {
+        const continuation = previousTrialCount
+          ? `<p style="color: rgba(148, 163, 184, 0.88);">Continuing from trial ${previousTrialCount + 1} with your uploaded staircases.</p>`
+          : '';
+        return `
+          <h1 style="margin-top:0">Just Noticeable Difference (Go/No-Go)</h1>
+          <p>
+            A coloured dot will flash twice. The first (odd-index) flash always marks the reference position and size.
+            After a brief random delay (50–1000 ms) the dot reappears in the same hue for the even-index comparison dot.
+          </p>
+          <p>
+            On most trials the dot is identical (<strong>no-go</strong>). About one third of the time the
+            dot shifts slightly in angle, distance from the centre, or diameter (<strong>go</strong> trials).
+          </p>
+          <ul>
+            <li>Press the spacebar or tap anywhere inside the display <strong>if the even-index (second) dot looks different</strong>.</li>
+            <li>If the comparison dot looks identical to the reference, do nothing.</li>
+          </ul>
+          <p>
+            The stimulus differences adapt during the experiment to maintain roughly 70% accuracy on go trials using the jsQuestPlus staircase.
+          </p>
+          <p>Find a comfortable viewing distance and keep your finger near the screen or the spacebar.</p>
+          ${continuation}
+        `;
+      },
       choices: ['Begin']
     };
 
-    timeline.push(instructions);
-
-    function createTrial(index) {
+    function createTrial(index, offset = 0) {
       const setup = {
         type: jsPsychCallFunction,
         func: () => {
-          jsPsych.setProgressBar(index / TOTAL_TRIALS);
+          const total = Math.max(progressTotal, 1);
+          jsPsych.setProgressBar((progressBase + index) / total);
           trialState = {
-            index: index + 1,
+            index: offset + index + 1,
             isGo: Math.random() < GO_PROBABILITY,
             isi: jsPsych.randomization.randomInt(50, 1000),
             changeType: 'none',
@@ -391,7 +825,7 @@
         stimulus: () => stageHTML(dotHTML(trialState.firstX, trialState.firstY, trialState.baseDiameter, trialState.dotColor)),
         choices: 'NO_KEYS',
         trial_duration: FIRST_STIM_DURATION,
-        data: { stage: 'stimulus_1', trial_index: index + 1 }
+        data: { stage: 'stimulus_1', trial_index: trialState.index }
       };
 
       const isi = {
@@ -407,7 +841,7 @@
         stimulus: () => stageHTML(dotHTML(trialState.secondX, trialState.secondY, trialState.secondDiameter, trialState.dotColor)),
         choices: 'NO_KEYS',
         trial_duration: SECOND_STIM_DURATION,
-        data: { stage: 'stimulus_2', trial_index: index + 1 }
+        data: { stage: 'stimulus_2', trial_index: trialState.index }
       };
 
       const response = {
@@ -499,39 +933,179 @@
       return [setup, fixation, firstStim, isi, secondStim, response];
     }
 
-    for (let i = 0; i < TOTAL_TRIALS; i++) {
-      timeline.push(...createTrial(i));
-    }
-
     const debrief = {
       type: jsPsychHtmlButtonResponse,
       stimulus: () => {
         jsPsych.setProgressBar(1);
-        const data = jsPsych.data.get();
-        const goTrials = data.filter({ stage: 'response', is_go: true });
-        const goHits = goTrials.filter({ go_success: true });
-        const noGoTrials = data.filter({ stage: 'response', is_go: false });
-        const correctNoGo = noGoTrials.filter({ correct: true });
-        const goRate = goTrials.count() ? Math.round((goHits.count() / goTrials.count()) * 100) : 0;
-        const noGoRate = noGoTrials.count() ? Math.round((correctNoGo.count() / noGoTrials.count()) * 100) : 0;
+        const newValues = jsPsych.data.get().values();
+        const combined = uploadedDataArray.length ? [...uploadedDataArray, ...newValues] : [...newValues];
+        const responseTrials = combined.filter(trial => trial && trial.stage === 'response');
+        const goTrials = responseTrials.filter(trial => trial?.is_go === true);
+        const goHits = goTrials.filter(trial => trial?.go_success === true);
+        const noGoTrials = responseTrials.filter(trial => trial?.is_go === false);
+        const correctNoGo = noGoTrials.filter(trial => trial?.correct === true);
+        const goRate = goTrials.length ? Math.round((goHits.length / goTrials.length) * 100) : 0;
+        const noGoRate = noGoTrials.length ? Math.round((correctNoGo.length / noGoTrials.length) * 100) : 0;
+        const previousCount = uploadedDataArray.length;
+        const newCount = newValues.length;
 
         return `
           <h2 style="margin-top:0">All done!</h2>
-          <p>You detected ${goHits.count()} of ${goTrials.count()} change trials (<strong>${goRate}%</strong> hit rate).</p>
-          <p>You withheld responses on ${correctNoGo.count()} of ${noGoTrials.count()} identical trials (<strong>${noGoRate}%</strong> correct rejections).</p>
-          <p>The adaptive staircases used jsQuestPlus to target roughly 70% success on change trials.</p>
-          <p>You can download a CSV of your responses for further analysis.</p>
+          <p>Your dataset now contains ${goHits.length} detections across ${goTrials.length} change trials (<strong>${goRate}%</strong> hit rate).</p>
+          <p>You withheld responses on ${correctNoGo.length} of ${noGoTrials.length} identical trials (<strong>${noGoRate}%</strong> correct rejections).</p>
+          <p>The combined JSON merges ${previousCount} previous records with ${newCount} new trials so you can keep building on the same staircases.</p>
+          <p>Click below to download the updated JSON along with a CSV of the newly collected block.</p>
         `;
       },
-      choices: ['Download data'],
+      choices: ['Download results'],
       on_finish: () => {
-        jsPsych.data.get().localSave('csv', 'jnd-go-nogo-data.csv');
+        const newValues = jsPsych.data.get().values();
+        const combined = uploadedDataArray.length ? [...uploadedDataArray, ...newValues] : [...newValues];
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+        downloadBlob(JSON.stringify(combined, null, 2), `jnd-go-nogo-${timestamp}.json`, 'application/json');
+        downloadBlob(jsPsych.data.get().csv(), `jnd-go-nogo-${timestamp}.csv`, 'text/csv');
+        uploadedDataArray = combined;
+        seedQuestsFromData(uploadedDataArray);
+        progressBase = previousTrialCount;
+        progressTotal = previousTrialCount + TOTAL_TRIALS;
+        if (viewButton) {
+          viewButton.disabled = uploadedDataArray.length === 0;
+        }
+        if (startButton) {
+          startButton.textContent = 'Run another block';
+        }
+        setStatus('Your combined dataset is ready. You can inspect the psychometrics or continue collecting data.', 'info');
+        if (preExperimentOverlay) {
+          preExperimentOverlay.classList.remove('hidden');
+        }
+        if (psychOutput) {
+          psychOutput.hidden = true;
+        }
+        destroyPsychCharts();
+        jsPsych.getDisplayElement().innerHTML = '';
       }
     };
 
-    timeline.push(debrief);
+    function buildTimeline(offset = 0) {
+      const timeline = [instructions];
+      for (let i = 0; i < TOTAL_TRIALS; i++) {
+        timeline.push(...createTrial(i, offset));
+      }
+      timeline.push(debrief);
+      return timeline;
+    }
 
-    jsPsych.run(timeline);
+    function startExperiment() {
+      progressBase = previousTrialCount;
+      progressTotal = previousTrialCount + TOTAL_TRIALS;
+      const timeline = buildTimeline(previousTrialCount);
+      if (preExperimentOverlay) {
+        preExperimentOverlay.classList.add('hidden');
+      }
+      destroyPsychCharts();
+      if (psychOutput) {
+        psychOutput.hidden = true;
+      }
+      jsPsych.run(timeline);
+    }
+
+    if (startButton) {
+      startButton.addEventListener('click', () => {
+        startExperiment();
+      });
+    }
+
+    if (viewButton) {
+      viewButton.addEventListener('click', () => {
+        if (viewButton.disabled) return;
+        renderPsychometricsFromData(uploadedDataArray);
+      });
+    }
+
+    if (fileInput) {
+      fileInput.addEventListener('change', event => {
+        destroyPsychCharts();
+        if (psychOutput) {
+          psychOutput.hidden = true;
+        }
+
+        const files = event.target.files || [];
+        const file = files[0];
+        if (!file) {
+          uploadedDataArray = [];
+          previousTrialCount = 0;
+          resetQuests();
+          progressBase = 0;
+          progressTotal = TOTAL_TRIALS;
+          if (startButton) startButton.textContent = 'Start experiment';
+          if (viewButton) viewButton.disabled = true;
+          setStatus('No previous session loaded.', 'info');
+          return;
+        }
+
+        const reader = new FileReader();
+        reader.onload = loadEvent => {
+          try {
+            const raw = JSON.parse(loadEvent.target.result);
+            const normalised = Array.isArray(raw)
+              ? raw
+              : Array.isArray(raw.data)
+              ? raw.data
+              : Array.isArray(raw.trials)
+              ? raw.trials
+              : [];
+            if (!Array.isArray(normalised)) {
+              throw new Error('Invalid JSON structure');
+            }
+            uploadedDataArray = normalised.filter(entry => entry && typeof entry === 'object');
+            seedQuestsFromData(uploadedDataArray);
+            progressBase = previousTrialCount;
+            progressTotal = previousTrialCount + TOTAL_TRIALS;
+            const responseCount = uploadedDataArray.filter(trial => trial && trial.stage === 'response').length;
+            let message = `Loaded ${uploadedDataArray.length} trials from ${file.name}.`;
+            if (previousTrialCount) {
+              message += ` Continuing from trial ${previousTrialCount + 1}.`;
+            }
+            if (responseCount) {
+              message += ` ${responseCount} response-stage records detected.`;
+            }
+            setStatus(message, 'info');
+            if (startButton) {
+              startButton.textContent = uploadedDataArray.length ? 'Continue experiment' : 'Start experiment';
+            }
+            if (viewButton) {
+              viewButton.disabled = uploadedDataArray.length === 0;
+            }
+          } catch (error) {
+            console.error(error);
+            uploadedDataArray = [];
+            previousTrialCount = 0;
+            resetQuests();
+            progressBase = 0;
+            progressTotal = TOTAL_TRIALS;
+            if (startButton) startButton.textContent = 'Start experiment';
+            if (viewButton) viewButton.disabled = true;
+            setStatus('Could not parse that JSON file. Please ensure it was exported from this experiment.', 'error');
+          } finally {
+            fileInput.value = '';
+          }
+        };
+        reader.onerror = () => {
+          uploadedDataArray = [];
+          previousTrialCount = 0;
+          resetQuests();
+          progressBase = 0;
+          progressTotal = TOTAL_TRIALS;
+          if (startButton) startButton.textContent = 'Start experiment';
+          if (viewButton) viewButton.disabled = true;
+          setStatus('Unable to read the selected file.', 'error');
+          fileInput.value = '';
+        };
+        reader.readAsText(file);
+      });
+    }
+
+    setStatus('No previous session loaded.', 'info');
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a pre-experiment overlay that lets people upload previous JSON data, continue a staircase, or inspect results
- seed the jsQuest staircases from uploaded trials and append new blocks to the exported JSON results
- render Chart.js psychometric curves for each change dimension so users can review thresholds without running new trials

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2243d9b8483218b6a37863da2b26f