### PR TITLE
Implement hold-to-run control for JND go/no-go task

### DIFF
--- a/experiments/jnd-go-nogo.html
+++ b/experiments/jnd-go-nogo.html
@@ -241,6 +241,48 @@
       margin-bottom: 16px;
     }
 
+    #hold-control,
+    #stop-control {
+      position: fixed;
+      z-index: 30;
+      border: none;
+      border-radius: clamp(18px, 5vw, 28px);
+      font-weight: 600;
+      font-size: clamp(0.95rem, 2.4vw, 1.15rem);
+      padding: clamp(16px, 4vw, 22px) clamp(28px, 6vw, 38px);
+      color: #0f172a;
+      background: linear-gradient(135deg, #f8fafc, #e2e8f0);
+      box-shadow: 0 24px 40px rgba(2, 6, 23, 0.35);
+      cursor: pointer;
+      touch-action: none;
+      transition: transform 180ms ease, box-shadow 180ms ease, opacity 180ms ease;
+    }
+
+    #hold-control {
+      bottom: clamp(16px, 4vw, 40px);
+      right: clamp(16px, 4vw, 40px);
+      background: linear-gradient(135deg, #34d399, #10b981);
+      color: #022c22;
+    }
+
+    #hold-control[data-state='active'] {
+      transform: translateY(1px);
+      box-shadow: inset 0 2px 0 rgba(2, 6, 23, 0.25);
+    }
+
+    #stop-control {
+      top: clamp(16px, 4vw, 40px);
+      left: clamp(16px, 4vw, 40px);
+      background: linear-gradient(135deg, #f87171, #ef4444);
+      color: #fee2e2;
+    }
+
+    #stop-control:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+      box-shadow: none;
+    }
+
     @media (max-width: 600px) {
       #pre-experiment {
         padding: 20px;
@@ -301,7 +343,7 @@
 
     const TARGET_ACCURACY = 0.7;
     const GO_PROBABILITY = 1 / 3;
-    const TOTAL_TRIALS = 100;
+    const TOTAL_TRIALS = 1000;
     const FIRST_STIM_DURATION = 33;
     const SECOND_STIM_DURATION = 33;
     const RESPONSE_WINDOW = 1400;
@@ -311,6 +353,9 @@
     let progressBase = 0;
     let progressTotal = TOTAL_TRIALS;
     let psychCharts = [];
+    let experimentRunning = false;
+    let hasFinalizedCurrentRun = false;
+    let currentHoldInfo = null;
 
     const stageSide = Math.min(window.innerWidth, window.innerHeight) * 0.7;
     document.documentElement.style.setProperty('--stage-size', `${Math.round(stageSide)}px`);
@@ -320,6 +365,187 @@
     const minRadius = Math.max(36, maxRadius * 0.28);
     const minDiameter = Math.max(18, stageSide * 0.08);
     const maxDiameter = Math.max(minDiameter + 16, stageSide * 0.32);
+
+    const holdController = (() => {
+      const state = {
+        isHolding: false,
+        source: null,
+        since: null,
+        pointerId: null
+      };
+      const waiters = [];
+      const releaseHandlers = new Set();
+      const changeHandlers = new Set();
+      let experimentActive = false;
+
+      const holdButton = document.createElement('button');
+      holdButton.id = 'hold-control';
+      holdButton.type = 'button';
+      holdButton.textContent = 'Hold to Run';
+      holdButton.dataset.state = 'idle';
+
+      const stopButton = document.createElement('button');
+      stopButton.id = 'stop-control';
+      stopButton.type = 'button';
+      stopButton.textContent = 'Stop & Download';
+      stopButton.disabled = true;
+
+      document.body.appendChild(stopButton);
+      document.body.appendChild(holdButton);
+
+      function updateButtons() {
+        holdButton.dataset.state = state.isHolding ? 'active' : 'idle';
+        holdButton.textContent = state.isHolding ? 'Holding…' : 'Hold to Run';
+        stopButton.disabled = state.isHolding || !experimentActive;
+      }
+
+      function beginHold(source, event) {
+        if (state.isHolding) return;
+        state.isHolding = true;
+        state.source = source;
+        state.since = performance.now();
+        state.pointerId = source === 'pointer' && event ? event.pointerId : null;
+        updateButtons();
+        while (waiters.length) {
+          const resolve = waiters.shift();
+          resolve({ source: state.source, since: state.since });
+        }
+        changeHandlers.forEach(handler => handler({ ...state }));
+      }
+
+      function finishHold(source, event) {
+        if (!state.isHolding) return;
+        if (source === 'pointer' && state.pointerId !== null && event && event.pointerId !== state.pointerId) {
+          return;
+        }
+        const start = state.since;
+        const releaseTime = performance.now();
+        const info = {
+          source,
+          time: releaseTime,
+          since: start,
+          holdDuration: start != null ? releaseTime - start : null,
+          pointerType: event?.pointerType ?? null,
+          key: event?.code ?? null
+        };
+        state.isHolding = false;
+        state.source = null;
+        state.since = null;
+        state.pointerId = null;
+        updateButtons();
+        changeHandlers.forEach(handler => handler({ ...state }));
+        releaseHandlers.forEach(handler => handler(info));
+      }
+
+      holdButton.addEventListener('pointerdown', event => {
+        if (event.button !== undefined && event.button !== 0 && event.pointerType !== 'touch') {
+          return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        if (typeof holdButton.setPointerCapture === 'function') {
+          try {
+            holdButton.setPointerCapture(event.pointerId);
+          } catch (error) {
+            /* noop */
+          }
+        }
+        beginHold('pointer', event);
+      });
+
+      const pointerEnd = event => {
+        if (event) {
+          event.preventDefault();
+          event.stopPropagation();
+        }
+        if (
+          event?.pointerId != null &&
+          typeof holdButton.releasePointerCapture === 'function' &&
+          (typeof holdButton.hasPointerCapture !== 'function' || holdButton.hasPointerCapture(event.pointerId))
+        ) {
+          holdButton.releasePointerCapture(event.pointerId);
+        }
+        finishHold('pointer', event);
+      };
+
+      holdButton.addEventListener('pointerup', pointerEnd);
+      holdButton.addEventListener('pointercancel', pointerEnd);
+      holdButton.addEventListener('lostpointercapture', pointerEnd);
+      holdButton.addEventListener('contextmenu', event => event.preventDefault());
+
+      const isTextInput = element => {
+        if (!element) return false;
+        const tag = element.tagName;
+        return tag === 'INPUT' || tag === 'TEXTAREA' || element.isContentEditable === true;
+      };
+
+      const keydownHandler = event => {
+        if (event.code !== 'Space' || isTextInput(event.target)) {
+          return;
+        }
+        if (event.repeat) {
+          event.preventDefault();
+          return;
+        }
+        event.preventDefault();
+        beginHold('keyboard', event);
+      };
+
+      const keyupHandler = event => {
+        if (event.code !== 'Space' || isTextInput(event.target)) {
+          return;
+        }
+        event.preventDefault();
+        finishHold('keyboard', event);
+      };
+
+      window.addEventListener('keydown', keydownHandler, { passive: false });
+      window.addEventListener('keyup', keyupHandler, { passive: false });
+
+      function waitForHold() {
+        return new Promise(resolve => {
+          if (state.isHolding) {
+            resolve({ source: state.source, since: state.since });
+          } else {
+            waiters.push(resolve);
+          }
+        });
+      }
+
+      function onRelease(handler) {
+        if (typeof handler !== 'function') {
+          return () => {};
+        }
+        releaseHandlers.add(handler);
+        return () => releaseHandlers.delete(handler);
+      }
+
+      function onChange(handler) {
+        if (typeof handler !== 'function') {
+          return () => {};
+        }
+        changeHandlers.add(handler);
+        return () => changeHandlers.delete(handler);
+      }
+
+      function setExperimentActive(active) {
+        experimentActive = Boolean(active);
+        updateButtons();
+      }
+
+      updateButtons();
+
+      return {
+        waitForHold,
+        onRelease,
+        onChange,
+        isHolding: () => state.isHolding,
+        getState: () => ({ ...state }),
+        setExperimentActive,
+        stopButton,
+        holdButton
+      };
+    })();
 
     function clamp(value, min, max) {
       return Math.min(max, Math.max(min, value));
@@ -685,6 +911,71 @@
       return `<div class="dot" style="left:${x}px; top:${y}px; width:${diameter}px; height:${diameter}px; background:${color.fill}; box-shadow:0 0 20px ${color.glow};"></div>`;
     }
 
+    function finalizeSession({ reason = 'completed', showOverlay = true } = {}) {
+      if (hasFinalizedCurrentRun) {
+        return [];
+      }
+      hasFinalizedCurrentRun = true;
+      experimentRunning = false;
+      holdController.setExperimentActive(false);
+      currentHoldInfo = null;
+
+      jsPsych.setProgressBar(1);
+
+      const newValues = jsPsych.data ? jsPsych.data.get().values() : [];
+      const combined = uploadedDataArray.length ? [...uploadedDataArray, ...newValues] : [...newValues];
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+
+      downloadBlob(JSON.stringify(combined, null, 2), `jnd-go-nogo-${timestamp}.json`, 'application/json');
+      if (newValues.length && reason !== 'stopped') {
+        downloadBlob(jsPsych.data.get().csv(), `jnd-go-nogo-${timestamp}.csv`, 'text/csv');
+      }
+
+      uploadedDataArray = combined;
+      seedQuestsFromData(uploadedDataArray);
+      progressBase = previousTrialCount;
+      progressTotal = previousTrialCount + TOTAL_TRIALS;
+
+      if (viewButton) {
+        viewButton.disabled = uploadedDataArray.length === 0;
+      }
+      if (startButton) {
+        startButton.textContent = 'Run another block';
+      }
+
+      const statusMessage =
+        reason === 'stopped'
+          ? 'Experiment stopped. Your data has been downloaded.'
+          : 'Block completed. Your data has been downloaded.';
+      setStatus(statusMessage, 'info');
+
+      if (showOverlay && preExperimentOverlay) {
+        preExperimentOverlay.classList.remove('hidden');
+      }
+      if (psychOutput) {
+        psychOutput.hidden = true;
+      }
+      destroyPsychCharts();
+
+      const display = jsPsych.getDisplayElement();
+      if (display) {
+        display.innerHTML = '';
+      }
+
+      if (typeof trialState.releaseCleanup === 'function') {
+        try {
+          trialState.releaseCleanup();
+        } catch (error) {
+          /* ignore */
+        }
+        trialState.releaseCleanup = null;
+      }
+      trialState.responseInfo = null;
+      trialState.pendingRelease = null;
+
+      return combined;
+    }
+
     let trialState = {};
 
     const instructions = {
@@ -704,13 +995,14 @@
             dot shifts slightly in angle, distance from the centre, or diameter (<strong>go</strong> trials).
           </p>
           <ul>
-            <li>Press the spacebar or tap anywhere inside the display <strong>if the even-index (second) dot looks different</strong>.</li>
-            <li>If the comparison dot looks identical to the reference, do nothing.</li>
+            <li>Hold the on-screen <strong>Hold to Run</strong> control (lower right) or keep the space bar held down to let trials play continuously.</li>
+            <li>Release the control as soon as the second flash looks different. Maintaining the hold signals “no change”.</li>
+            <li>While released you can tap the upper-left <strong>Stop &amp; Download</strong> button to end early and save everything collected so far.</li>
           </ul>
           <p>
             The stimulus differences adapt during the experiment to maintain roughly 70% accuracy on go trials using the jsQuestPlus staircase.
           </p>
-          <p>Find a comfortable viewing distance and keep your finger near the screen or the spacebar.</p>
+          <p>Find a comfortable viewing distance and rest your finger on the hold control or space bar between trials.</p>
           ${continuation}
         `;
       },
@@ -718,13 +1010,63 @@
     };
 
     function createTrial(index, offset = 0) {
+      const awaitHold = {
+        type: jsPsychCallFunction,
+        async: true,
+        func: done => {
+          holdController.waitForHold().then(state => {
+            currentHoldInfo = state ? { ...state } : null;
+            done();
+          });
+        }
+      };
+
+      function handleReleaseEvent(info) {
+        if (!info) return;
+        trialState.lastRelease = info;
+        if (!trialState.responseActive || !trialState.responseInfo) {
+          trialState.pendingRelease = info;
+          return;
+        }
+        if (trialState.responseInfo.responded) {
+          return;
+        }
+
+        const responseSource = info.source || (info.key ? 'keyboard' : 'pointer');
+        const base =
+          typeof trialState.changeOnset === 'number' ? trialState.changeOnset : trialState.responseInfo.start;
+        const rt = base != null ? Math.max(0, info.time - base) : null;
+
+        trialState.responseInfo.responded = true;
+        trialState.responseInfo.source = responseSource;
+        trialState.responseInfo.rt = rt;
+        trialState.responseInfo.holdDuration =
+          typeof info.holdDuration === 'number'
+            ? info.holdDuration
+            : info.since != null
+            ? info.time - info.since
+            : null;
+        trialState.responseInfo.releaseTime = info.time;
+        trialState.responseInfo.pointerType = info.pointerType ?? null;
+        trialState.responseInfo.key = info.key ?? null;
+        trialState.pendingRelease = null;
+
+        jsPsych.finishTrial({ rt, response: responseSource });
+      }
+
       const setup = {
         type: jsPsychCallFunction,
         func: () => {
           const total = Math.max(progressTotal, 1);
           jsPsych.setProgressBar((progressBase + index) / total);
+
+          const holdInfo = currentHoldInfo ? { ...currentHoldInfo } : null;
+
           trialState = {
             index: offset + index + 1,
+            holdInfo,
+            holdSource: holdInfo?.source ?? 'none',
+            holdStart: holdInfo?.since ?? null,
             isGo: Math.random() < GO_PROBABILITY,
             isi: jsPsych.randomization.randomInt(50, 1000),
             changeType: 'none',
@@ -732,7 +1074,14 @@
             questRef: null,
             deltaTheta: 0,
             deltaRadius: 0,
-            deltaDiameter: 0
+            deltaDiameter: 0,
+            pendingRelease: null,
+            responseActive: false,
+            responseInfo: null,
+            releaseCleanup: null,
+            changeOnset: null,
+            lastRelease: null,
+            trialStart: performance.now()
           };
 
           const dotColor = createDotColor();
@@ -809,6 +1158,11 @@
           trialState.firstY = firstCoords.y;
           trialState.secondX = secondCoords.x;
           trialState.secondY = secondCoords.y;
+
+          if (trialState.releaseCleanup) {
+            trialState.releaseCleanup();
+          }
+          trialState.releaseCleanup = holdController.onRelease(handleReleaseEvent);
         }
       };
 
@@ -838,61 +1192,46 @@
 
       const secondStim = {
         type: jsPsychHtmlKeyboardResponse,
-        stimulus: () => stageHTML(dotHTML(trialState.secondX, trialState.secondY, trialState.secondDiameter, trialState.dotColor)),
+        stimulus: () =>
+          stageHTML(dotHTML(trialState.secondX, trialState.secondY, trialState.secondDiameter, trialState.dotColor)),
         choices: 'NO_KEYS',
         trial_duration: SECOND_STIM_DURATION,
-        data: { stage: 'stimulus_2', trial_index: trialState.index }
+        data: { stage: 'stimulus_2', trial_index: trialState.index },
+        on_load: () => {
+          trialState.changeOnset = performance.now();
+        }
       };
 
       const response = {
         type: jsPsychHtmlKeyboardResponse,
-        stimulus: () => stageHTML(`<div class="response-text">Tap anywhere or press SPACE if the second dot was different.</div>`),
+        stimulus: () => stageHTML(),
         choices: 'NO_KEYS',
         trial_duration: RESPONSE_WINDOW,
         data: { stage: 'response' },
         on_load: () => {
-          const display = jsPsych.getDisplayElement();
-          const start = performance.now();
+          trialState.responseActive = true;
           trialState.responseInfo = {
             responded: false,
             source: 'none',
-            rt: null
+            rt: null,
+            holdDuration: null,
+            start: performance.now(),
+            releaseTime: null,
+            pointerType: null,
+            key: null
           };
 
-          trialState.responseInfo.keyboardListener = jsPsych.pluginAPI.getKeyboardResponse({
-            callback_function: info => {
-              if (trialState.responseInfo.responded) return;
-              trialState.responseInfo.responded = true;
-              trialState.responseInfo.source = 'keyboard';
-              trialState.responseInfo.rt = info.rt;
-              display.removeEventListener('pointerdown', trialState.responseInfo.pointerHandler);
-              jsPsych.finishTrial({ rt: info.rt, response: 'keyboard' });
-            },
-            valid_responses: [' '],
-            rt_method: 'performance',
-            persist: false,
-            allow_held_key: false
-          });
-
-          trialState.responseInfo.pointerHandler = event => {
-            if (trialState.responseInfo.responded) return;
-            trialState.responseInfo.responded = true;
-            trialState.responseInfo.source = event.pointerType || 'pointer';
-            trialState.responseInfo.rt = performance.now() - start;
-            jsPsych.pluginAPI.cancelKeyboardResponse(trialState.responseInfo.keyboardListener);
-            display.removeEventListener('pointerdown', trialState.responseInfo.pointerHandler);
-            jsPsych.finishTrial({ rt: trialState.responseInfo.rt, response: 'pointer' });
-          };
-
-          display.addEventListener('pointerdown', trialState.responseInfo.pointerHandler);
+          if (trialState.pendingRelease) {
+            const pending = trialState.pendingRelease;
+            trialState.pendingRelease = null;
+            handleReleaseEvent(pending);
+          }
         },
         on_finish: data => {
-          const display = jsPsych.getDisplayElement();
-          if (trialState.responseInfo?.pointerHandler) {
-            display.removeEventListener('pointerdown', trialState.responseInfo.pointerHandler);
-          }
-          if (trialState.responseInfo?.keyboardListener) {
-            jsPsych.pluginAPI.cancelKeyboardResponse(trialState.responseInfo.keyboardListener);
+          trialState.responseActive = false;
+          if (typeof trialState.releaseCleanup === 'function') {
+            trialState.releaseCleanup();
+            trialState.releaseCleanup = null;
           }
 
           const responded = Boolean(trialState.responseInfo?.responded);
@@ -901,6 +1240,17 @@
 
           data.rt = rt;
           data.response_source = source;
+          data.hold_source = trialState.holdSource;
+          data.hold_start = trialState.holdStart ?? null;
+          data.hold_duration = trialState.responseInfo?.holdDuration ?? null;
+          data.release_time = trialState.responseInfo?.releaseTime ?? null;
+          data.release_pointer_type = trialState.responseInfo?.pointerType ?? null;
+          data.release_key = trialState.responseInfo?.key ?? null;
+          data.released_before_change =
+            typeof trialState.changeOnset === 'number' && trialState.lastRelease
+              ? trialState.lastRelease.time < trialState.changeOnset
+              : false;
+          data.trial_started = trialState.trialStart ?? null;
           data.is_go = trialState.isGo;
           data.change_type = trialState.changeType;
           data.delta_theta = trialState.deltaTheta;
@@ -927,62 +1277,19 @@
               console.warn('Quest update skipped', error);
             }
           }
+
+          trialState.responseInfo = null;
+          trialState.pendingRelease = null;
         }
       };
 
-      return [setup, fixation, firstStim, isi, secondStim, response];
+      return [awaitHold, setup, fixation, firstStim, isi, secondStim, response];
     }
 
-    const debrief = {
-      type: jsPsychHtmlButtonResponse,
-      stimulus: () => {
-        jsPsych.setProgressBar(1);
-        const newValues = jsPsych.data.get().values();
-        const combined = uploadedDataArray.length ? [...uploadedDataArray, ...newValues] : [...newValues];
-        const responseTrials = combined.filter(trial => trial && trial.stage === 'response');
-        const goTrials = responseTrials.filter(trial => trial?.is_go === true);
-        const goHits = goTrials.filter(trial => trial?.go_success === true);
-        const noGoTrials = responseTrials.filter(trial => trial?.is_go === false);
-        const correctNoGo = noGoTrials.filter(trial => trial?.correct === true);
-        const goRate = goTrials.length ? Math.round((goHits.length / goTrials.length) * 100) : 0;
-        const noGoRate = noGoTrials.length ? Math.round((correctNoGo.length / noGoTrials.length) * 100) : 0;
-        const previousCount = uploadedDataArray.length;
-        const newCount = newValues.length;
-
-        return `
-          <h2 style="margin-top:0">All done!</h2>
-          <p>Your dataset now contains ${goHits.length} detections across ${goTrials.length} change trials (<strong>${goRate}%</strong> hit rate).</p>
-          <p>You withheld responses on ${correctNoGo.length} of ${noGoTrials.length} identical trials (<strong>${noGoRate}%</strong> correct rejections).</p>
-          <p>The combined JSON merges ${previousCount} previous records with ${newCount} new trials so you can keep building on the same staircases.</p>
-          <p>Click below to download the updated JSON along with a CSV of the newly collected block.</p>
-        `;
-      },
-      choices: ['Download results'],
-      on_finish: () => {
-        const newValues = jsPsych.data.get().values();
-        const combined = uploadedDataArray.length ? [...uploadedDataArray, ...newValues] : [...newValues];
-        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-        downloadBlob(JSON.stringify(combined, null, 2), `jnd-go-nogo-${timestamp}.json`, 'application/json');
-        downloadBlob(jsPsych.data.get().csv(), `jnd-go-nogo-${timestamp}.csv`, 'text/csv');
-        uploadedDataArray = combined;
-        seedQuestsFromData(uploadedDataArray);
-        progressBase = previousTrialCount;
-        progressTotal = previousTrialCount + TOTAL_TRIALS;
-        if (viewButton) {
-          viewButton.disabled = uploadedDataArray.length === 0;
-        }
-        if (startButton) {
-          startButton.textContent = 'Run another block';
-        }
-        setStatus('Your combined dataset is ready. You can inspect the psychometrics or continue collecting data.', 'info');
-        if (preExperimentOverlay) {
-          preExperimentOverlay.classList.remove('hidden');
-        }
-        if (psychOutput) {
-          psychOutput.hidden = true;
-        }
-        destroyPsychCharts();
-        jsPsych.getDisplayElement().innerHTML = '';
+    const completeBlock = {
+      type: jsPsychCallFunction,
+      func: () => {
+        finalizeSession({ reason: 'completed' });
       }
     };
 
@@ -991,11 +1298,15 @@
       for (let i = 0; i < TOTAL_TRIALS; i++) {
         timeline.push(...createTrial(i, offset));
       }
-      timeline.push(debrief);
+      timeline.push(completeBlock);
       return timeline;
     }
 
     function startExperiment() {
+      hasFinalizedCurrentRun = false;
+      experimentRunning = true;
+      currentHoldInfo = null;
+      holdController.setExperimentActive(true);
       progressBase = previousTrialCount;
       progressTotal = previousTrialCount + TOTAL_TRIALS;
       const timeline = buildTimeline(previousTrialCount);
@@ -1008,6 +1319,14 @@
       }
       jsPsych.run(timeline);
     }
+
+    holdController.stopButton.addEventListener('click', () => {
+      if (holdController.isHolding() || !experimentRunning || hasFinalizedCurrentRun) {
+        return;
+      }
+      jsPsych.endExperiment('Experiment stopped. Preparing download…');
+      finalizeSession({ reason: 'stopped' });
+    });
 
     if (startButton) {
       startButton.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Add fixed on-screen hold and stop controls with updated instructions and increase the session to 1000 trials
- Require an active hold before each trial, detect change reports on release, and capture hold metadata without end-of-trial prompts
- Finalize sessions via the stop button or automatic completion to download JSON results without extra questions

## Testing
- No automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d5137ed43483218e79db7b3074cc3f