### PR TITLE
Keep fixation cross visible during stimuli and fix psychometric view

### DIFF
--- a/experiments/jnd-go-nogo.html
+++ b/experiments/jnd-go-nogo.html
@@ -219,10 +219,15 @@
     }
 
     .fixation {
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%);
       font-size: clamp(36px, 7vw, 64px);
       font-weight: 600;
       color: rgba(241, 245, 249, 0.85);
       text-shadow: 0 8px 30px rgba(15, 23, 42, 0.7);
+      pointer-events: none;
     }
 
     .response-text {
@@ -703,6 +708,8 @@
         return;
       }
 
+      psychOutput.hidden = false;
+
       const changeTypes = [
         { key: 'theta', label: 'Angular shift', unit: '°', color: '#38bdf8', quest: () => thetaQuest, samples: thetaSamples },
         { key: 'radius', label: 'Radial displacement', unit: 'px', color: '#22c55e', quest: () => radiusQuest, samples: radiusSamples },
@@ -920,8 +927,9 @@
       return chosen;
     }
 
-    function stageHTML(content = '') {
-      return `<div class="stage">${content}</div>`;
+    function stageHTML(content = '', { showFixation = false } = {}) {
+      const fixation = showFixation ? '<div class="fixation">+</div>' : '';
+      return `<div class="stage">${fixation}${content}</div>`;
     }
 
     function createDotColor() {
@@ -1120,7 +1128,7 @@
 
       const fixation = {
         type: jsPsychHtmlKeyboardResponse,
-        stimulus: () => stageHTML('<div class="fixation">+</div>'),
+        stimulus: () => stageHTML('', { showFixation: true }),
         choices: 'NO_KEYS',
         trial_duration: 350,
         data: { stage: 'fixation' }
@@ -1128,7 +1136,10 @@
 
       const firstStim = {
         type: jsPsychHtmlKeyboardResponse,
-        stimulus: () => stageHTML(dotHTML(trialState.firstX, trialState.firstY, trialState.baseDiameter, trialState.dotColor)),
+        stimulus: () =>
+          stageHTML(dotHTML(trialState.firstX, trialState.firstY, trialState.baseDiameter, trialState.dotColor), {
+            showFixation: true
+          }),
         choices: 'NO_KEYS',
         trial_duration: FIRST_STIM_DURATION,
         data: { stage: 'stimulus_1', trial_index: trialState.index }
@@ -1136,7 +1147,7 @@
 
       const isi = {
         type: jsPsychHtmlKeyboardResponse,
-        stimulus: () => stageHTML(),
+        stimulus: () => stageHTML('', { showFixation: true }),
         choices: 'NO_KEYS',
         trial_duration: () => trialState.isi,
         data: { stage: 'isi' }
@@ -1144,7 +1155,10 @@
 
       const secondStim = {
         type: jsPsychHtmlKeyboardResponse,
-        stimulus: () => stageHTML(dotHTML(trialState.secondX, trialState.secondY, trialState.secondDiameter, trialState.dotColor)),
+        stimulus: () =>
+          stageHTML(dotHTML(trialState.secondX, trialState.secondY, trialState.secondDiameter, trialState.dotColor), {
+            showFixation: true
+          }),
         choices: 'NO_KEYS',
         trial_duration: SECOND_STIM_DURATION,
         on_load: () => {


### PR DESCRIPTION
## Summary
- keep the go/no-go fixation cross visible during both stimulus presentations and remove it after the second stimulus
- adjust the fixation cross styling so it overlays the stage without blocking pointer events
- unhide the psychometrics panel before rendering charts so uploaded data produces visible plots

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6b7c036a88321b0a1e65d156a415f