### PR TITLE
Add adaptive No-Go controller to JND Go/No-Go experiment

### DIFF
--- a/experiments/jnd-go-nogo.html
+++ b/experiments/jnd-go-nogo.html
@@ -332,6 +332,7 @@
   <script src="https://unpkg.com/jsquest-plus@2.1.0/dist/jsQuestPlus.js"></script>
   <!-- Context-aware QUEST+ -->
   <script src="adaptiveQuest.js"></script>
+  <script type="module" src="noGoController.js"></script>
   <script> initAdaptiveQuest(); </script>
 
   <script>
@@ -348,7 +349,6 @@
     const holdButton = document.getElementById('hold-button');
     const stopExperimentButton = document.getElementById('stop-experiment');
 
-    const GO_PROBABILITY = 1 / 3;
     const TOTAL_TRIALS = 1000;
     const FIRST_STIM_DURATION = 33;
     const SECOND_STIM_DURATION = 33;
@@ -747,9 +747,13 @@
           const total = Math.max(progressTotal, 1);
           jsPsych.setProgressBar((progressBase + index) / total);
           const holdStartedAt = typeof lastHoldStartTime === 'number' ? lastHoldStartTime : holdState.holdStart ?? null;
+          const ctrl = typeof NoGoCtrl !== 'undefined' ? NoGoCtrl : null;
+          const isNoGo = ctrl && typeof ctrl.decideNoGo === 'function' ? ctrl.decideNoGo() : false;
+
           trialState = {
             index: offset + index + 1,
-            isGo: Math.random() < GO_PROBABILITY,
+            isNoGo,
+            isGo: !isNoGo,
             isi: jsPsych.randomization.randomInt(50, 1000),
             changeType: 'none',
             questStimValue: null,
@@ -976,9 +980,15 @@
               : null;
           const source = responded ? result.response_source || holdState.primarySource || 'none' : 'none';
 
+          const ctrl = typeof NoGoCtrl !== 'undefined' ? NoGoCtrl : null;
+          if (ctrl && typeof ctrl.onTrialEnd === 'function') {
+            ctrl.onTrialEnd({ isNoGo: trialState.isNoGo === true, responded });
+          }
+
           data.rt = rt;
           data.response_source = source;
           data.is_go = trialState.isGo;
+          data.is_no_go = trialState.isNoGo;
           data.change_type = trialState.changeType;
           data.delta_theta = trialState.deltaTheta;
           data.delta_radius = trialState.deltaRadius;

--- a/experiments/noGoController.js
+++ b/experiments/noGoController.js
@@ -1,0 +1,60 @@
+const NoGoCtrl = (() => {
+  const cfg = {
+    pTargetFA: 0.05,
+    fBase: 0.18,
+    fMin: 0.1,
+    fMax: 0.45,
+    Kp: 2.0,
+    emaAlpha: 0.12
+  };
+
+  let faEma = null;
+  let nNoGo = 0;
+  let nFA = 0;
+
+  function onTrialEnd({ isNoGo, responded }) {
+    if (!isNoGo) return;
+    nNoGo += 1;
+    if (responded) nFA += 1;
+    const obs = responded ? 1 : 0;
+    if (faEma === null) {
+      faEma = obs;
+    } else {
+      faEma = (1 - cfg.emaAlpha) * faEma + cfg.emaAlpha * obs;
+    }
+  }
+
+  function estFA() {
+    return faEma === null ? cfg.pTargetFA : faEma;
+  }
+
+  function pNoGo() {
+    const err = Math.max(0, estFA() - cfg.pTargetFA);
+    let f = cfg.fBase + cfg.Kp * err;
+    if (f < cfg.fMin) f = cfg.fMin;
+    if (f > cfg.fMax) f = cfg.fMax;
+    return f;
+  }
+
+  function decideNoGo() {
+    return Math.random() < pNoGo();
+  }
+
+  function stats() {
+    return {
+      pNoGo: pNoGo(),
+      faEma,
+      nNoGo,
+      nFA,
+      params: { ...cfg }
+    };
+  }
+
+  return { onTrialEnd, decideNoGo, stats };
+})();
+
+if (typeof window !== 'undefined') {
+  window.NoGoCtrl = NoGoCtrl;
+}
+
+export default NoGoCtrl;


### PR DESCRIPTION
## Summary
- add a configurable EMA-based No-Go controller module for adaptive catch trial sampling
- integrate the controller into the JND Go/No-Go setup and log per-trial outcomes for feedback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8e7f697ac8321a075885ce8c5586c