### PR TITLE
Fix Spatial Backward Masking black screen

### DIFF
--- a/experiments/spatial-backward-masking.js
+++ b/experiments/spatial-backward-masking.js
@@ -424,6 +424,12 @@ export function run() {
   consecutiveMisses = 0;
 
   const timeline = buildTimeline();
+  timeline.unshift({
+    type: jsPsychCallFunction,
+    func: () => {
+      jsPsych.getDisplayElement().appendChild(stage);
+    }
+  });
   jsPsych.run(timeline);
 }
 


### PR DESCRIPTION
This PR fixes a bug in the Spatial Backward Masking experiment where running the task resulted in a permanent black screen instead of showing the trial sequence.

**Cause**: 
`jsPsych.run()` automatically clears the inner HTML of its target `display_element` when it starts the timeline. The `#experiment-stage` container, which holds the visual components for this experiment (the fixation dot, target, and masks), was hardcoded inside the `jspsych-target` div. Consequently, it was permanently removed from the DOM before any trials executed.

**Fix**:
In `experiments/spatial-backward-masking.js`, an initial `jsPsychCallFunction` node was unshifted onto the jsPsych timeline. This node fires immediately on startup and safely re-appends the detached `#experiment-stage` element into the jsPsych container, restoring full visual functionality.

**Verification**:
- Validated via Playwright frontend testing.
- The UI successfully renders the timeline, progress bar, trial text, and central fixation dot, bypassing the black screen.
- Ran the existing test suite successfully.

---
*PR created automatically by Jules for task [14772569013547874330](https://jules.google.com/task/14772569013547874330) started by @jobellet*