### PR TITLE
Update incidental memory attentional blink experiment masks and targets

### DIFF
--- a/experiments/attentional-blink-incidental/index.html
+++ b/experiments/attentional-blink-incidental/index.html
@@ -16,6 +16,14 @@
 
   <style>
     /* Add custom CSS here */
+    #loading-message {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      font-size: 24px;
+      z-index: 1000;
+    }
     body {
       background-color: #808080; /* Gray background typical for psychophysics */
       color: #ffffff;
@@ -58,7 +66,11 @@
   </style>
 </head>
 <body>
+  <div id="loading-message">Loading experiment, generating masks...</div>
   <script>
+    // Wrap entire logic in an IIFE so we can await mask generation
+    (async function initExperiment() {
+
     // Initialize jsPsych
     const jsPsych = initJsPsych({
       on_finish: function() {
@@ -83,7 +95,7 @@
     const global_target = generatePlaceholder("#ff4444", "Global Target (S1)");
 
     // 2. S2 Images (Highly memorable intact images)
-        const s2_images = [
+    const s2_images = [
       '../../assets/highly_memorable_targets/baby_17s.jpg',
       '../../assets/highly_memorable_targets/beard_11s.jpg',
       '../../assets/highly_memorable_targets/bench_02s.jpg',
@@ -186,18 +198,69 @@
       '../../assets/highly_memorable_targets/wooden_leg_01b.jpg',
     ];
 
+    // Helper: shuffle array in place
+    function shuffleArray(array) {
+      for (let i = array.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [array[i], array[j]] = [array[j], array[i]];
+      }
+      return array;
+    }
+
+    const shuffled_s2_images = shuffleArray([...s2_images]);
+    const presented_images = shuffled_s2_images.slice(0, 50);
+    const unpresented_images = shuffled_s2_images.slice(50, 100);
+
 
     // 3. Novel Images (Decoys for Phase 3)
-    const novel_images = [];
-    for (let i = 1; i <= 10; i++) {
-        novel_images.push(generatePlaceholder("#ffaa00", `Decoy Image ${i}`));
-    }
+    const novel_images = unpresented_images; // We use unpresented images as decoys
 
     // 4. Masks (Scrambled images)
-    const masks = [];
-    for (let i = 1; i <= 20; i++) {
-        masks.push(generatePlaceholder("#444444", `Mask ${i}`));
+    function generateShuffledMask(imageSrc) {
+      return new Promise((resolve, reject) => {
+        const img = new Image();
+        img.crossOrigin = 'Anonymous';
+        img.onload = () => {
+          const size = 300;
+          const gridSize = 10;
+          const tileSize = size / gridSize;
+
+          const tileCoords = [];
+          for (let y = 0; y < gridSize; y++) {
+            for (let x = 0; x < gridSize; x++) {
+              tileCoords.push({ x, y });
+            }
+          }
+
+          shuffleArray(tileCoords);
+          const maskedCanvas = document.createElement('canvas');
+          maskedCanvas.width = size;
+          maskedCanvas.height = size;
+          const maskedCtx = maskedCanvas.getContext('2d');
+
+          const sW = img.naturalWidth / gridSize;
+          const sH = img.naturalHeight / gridSize;
+
+          let i = 0;
+          for (let y = 0; y < gridSize; y++) {
+            for (let x = 0; x < gridSize; x++) {
+              const src = tileCoords[i++];
+              maskedCtx.drawImage(
+                img,
+                src.x * sW, src.y * sH, sW, sH,
+                x * tileSize, y * tileSize, tileSize, tileSize
+              );
+            }
+          }
+          resolve(maskedCanvas.toDataURL());
+        };
+        img.onerror = () => reject(new Error('Failed to load image for masking.'));
+        img.src = imageSrc;
+      });
     }
+
+    // Generate masks from unpresented images
+    const masks = await Promise.all(unpresented_images.map(src => generateShuffledMask(src)));
 
     // Combine all images for preloading
     const all_images = [global_target, ...s2_images, ...novel_images, ...masks];
@@ -231,20 +294,11 @@
     timeline.push(phase1_instructions);
 
     // --- Phase 2: RSVP Streams ---
-    const num_trials = s2_images.length;
+    const num_trials = presented_images.length;
     const rsvp_trials = [];
 
-    // Helper: shuffle array in place
-    function shuffleArray(array) {
-      for (let i = array.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [array[i], array[j]] = [array[j], array[i]];
-      }
-      return array;
-    }
-
     // Prepare trials
-    let available_s2 = shuffleArray([...s2_images]);
+    let available_s2 = shuffleArray([...presented_images]);
     const trial_variables = [];
 
     // We want a mix of short (Lag 2 or 3) and long (Lag 8) lags
@@ -414,7 +468,7 @@
 
     const memory_trials = [];
     // We will test all S2 images used in the RSVP phase
-    const used_s2 = s2_images.slice(0, num_trials); // They were all used, but keeping it general
+    const used_s2 = presented_images;
     let available_decoys = shuffleArray([...novel_images]);
 
     for (let i = 0; i < num_trials; i++) {
@@ -473,8 +527,11 @@
         choices: ['Continue']
     });
 
-    // Run the experiment
+    // Hide loading message and run the experiment
+    document.getElementById('loading-message').style.display = 'none';
     jsPsych.run(timeline);
+
+    })(); // End of initExperiment
 
   </script>
 </body>

--- a/serve.log
+++ b/serve.log
@@ -1,0 +1,307 @@
+ INFO  Accepting connections at http://localhost:3000
+ HTTP  4/18/2026 8:14:28 PM ::1 GET /experiments/attentional-blink-incidental/index.html
+ HTTP  4/18/2026 8:14:28 PM ::1 Returned 301 in 18 ms
+ HTTP  4/18/2026 8:14:28 PM ::1 GET /experiments/attentional-blink-incidental/index
+ HTTP  4/18/2026 8:14:28 PM ::1 Returned 301 in 1 ms
+ HTTP  4/18/2026 8:14:28 PM ::1 GET /experiments/attentional-blink-incidental
+ HTTP  4/18/2026 8:14:28 PM ::1 Returned 200 in 5 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/cheeseburger_10s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 3 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/leotard_05s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/duck_09s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/mulberry_03s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/handprint_01b.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/toothpick_11s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/tarantula_07s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 21 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 22 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 17 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 18 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 7 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 21 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/pasta_08s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/binder_21s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/nail_04s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/seesaw_12s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 3 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 4 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/string_cheese_04s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/pepperoni_08s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/chute_10s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 4 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/visor_08s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 4 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 9 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 12 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 8 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/beard_11s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/hula_hoop_15s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 4 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 2 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/sonogram_08s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 3 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 21 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/bikini_08s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/suspenders_12s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/nest_04s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/baby_17s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/mustache_13s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 4 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 4 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 5 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 6 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 11 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/turf_09s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/snowball_08s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/ramp_05s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/tack_03s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 6 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 6 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 7 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 6 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/whistle_11s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/sequin_05s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/torso_05s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/pancake_11s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/license_plate_03s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/pipe1_04s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 13 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 7 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 6 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 8 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 6 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 10 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/eclair_04s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 4 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/gold_04s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/lip_balm_11s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/contact_lens_12s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 4 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/cape_07s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 4 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/cummerbund_14s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 4 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 11 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/nacho_04s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 2 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/cummerbund_03s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 7 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/stiletto_06s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/tube_top_12s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/piglet_02s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 7 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/macaroni_14s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 4 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 5 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 5 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 3 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/spam_02s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/crayon_09s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/macaroni_01b.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/ear_09s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 GET /assets/highly_memorable_targets/straw2_14s.jpg
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 14 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 11 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 19 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 16 ms
+ HTTP  4/18/2026 8:14:29 PM ::1 Returned 200 in 16 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/baby_17s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/bench_02s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/bologna_12s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/beard_11s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 2 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 0 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/bikini_08s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/binder_21s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 4 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/brass_knuckles_04s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/bumper_12s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/calf2_03s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/candy_bar_04s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/chaps_04s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/cape_07s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/cheeseburger_10s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 3 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/chute_10s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 6 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 3 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 7 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/comic_book_15s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/contact_lens_12s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 9 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 3 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 5 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/crayon_09s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/cummerbund_03s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/dip_06s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/cummerbund_14s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/doorstop_10s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/duck_09s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 2 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 2 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 2 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 2 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 3 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 5 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/egg_roll_09n.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/ear_09s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 2 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/eclair_04s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/footbath_01s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/footprint_01b.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/giraffe_06s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/gorilla_13s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/gold_04s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 3 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/handprint_01b.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/headband_02s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 2 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 2 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/headscarf_11s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 9 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 7 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/hula_hoop_15s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/juicer1_10s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 2 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 4 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/kilt_01b.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/leotard_05s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/license_plate_03s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 3 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/lip_balm_11s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/loincloth_01b.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/macaroni_01b.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 7 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 2 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/macaroni_14s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 27 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 6 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 3 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/marker_13s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 23 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 3 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/memory_stick_16s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/mouthpiece_02s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/mulberry_03s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 4 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 2 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/mullet_06s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/mustache_03s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 11 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/mustache_07s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 9 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 5 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 4 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/mustache_13s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/nacho_04s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/nail_04s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/nest_04s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/notepad_03s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/orange_rind_14s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 3 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/pancake_11s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/panther_01b.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/parfait_15s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 3 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 3 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/pasta_08s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 4 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/peppermint_07s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 2 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/pig_06s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/pepperoni_08s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/piglet_02s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/pipe1_04s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 0 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 3 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/plaster_cast_02s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/pug_05s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/rack1_07s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/screen2_01b.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/ramp_05s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/seesaw_12s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 8 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 8 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 11 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 14 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 13 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/sequin_05s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 12 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/shelf_07s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/snowball_08s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/sonogram_08s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/splinter_11s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/spam_02s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/springboard_13s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 2 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/spur_03s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 2 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 2 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/stockings_12s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/stiletto_06s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/straw2_14s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/string_cheese_04s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/suspenders_12s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 2 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 2 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 2 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 8 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 6 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/sweater_19s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/swimsuit_06s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/tack_03s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/tamale_06s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 3 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/tarantula_07s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 4 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 3 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/test_tube_01b.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/toilet_paper_01b.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/turban_07s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/toothpick_11s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/torso_05s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/tube_top_12s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/turf_09s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 4 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/videogame_01b.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/visor_08s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/whistle_11s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 1 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 304 in 0 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/wig_14s.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 GET /assets/highly_memorable_targets/wooden_leg_01b.jpg
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 5 ms
+ HTTP  4/18/2026 8:14:31 PM ::1 Returned 200 in 5 ms


### PR DESCRIPTION
This PR updates the incidental memory attentional blink experiment to accurately separate target stimuli into presented and unpresented pools. It generates scrambled, tile-based masks using the unpresented images so they act purely as distractors in the rapid serial visual presentation phase, without priming the subsequent 2AFC memory test. The unpresented images are then successfully reused as decoys for the final testing phase.

---
*PR created automatically by Jules for task [17770789438443442668](https://jules.google.com/task/17770789438443442668) started by @jobellet*