### PR TITLE
Update dual image masking choices to exactly 3

### DIFF
--- a/experiments/dual-image-masking.html
+++ b/experiments/dual-image-masking.html
@@ -252,7 +252,7 @@
       <h1>Dual Image Masking</h1>
       <p>
         On each trial, two images will flash briefly in rapid succession.
-        Afterwards, you will see 10 images. Please click the two images you saw.
+        Afterwards, you will see 3 images. Please click the two images you saw.
       </p>
       <div class="controls">
         <button class="primary" id="start-button" disabled>Preparing stimuli…</button>

--- a/experiments/dual-image-masking.js
+++ b/experiments/dual-image-masking.js
@@ -151,7 +151,7 @@ function initQuest() {
   const soaFrames = [1, 2, 3, 4, 5, 6, 7]; // 1-7 frames
   const alphas = [1, 2, 3, 4, 5, 6, 7]; // threshold guesses
   const betas = [1, 2, 3, 4]; // slopes
-  const guessRates = [0.20]; // 2/10 chance of randomly picking T1
+  const guessRates = [2/3]; // 2/3 chance of randomly picking T1
   const lapseRates = [0.01, 0.02, 0.05];
 
   questEngine = new jsQuestPlus({
@@ -274,8 +274,11 @@ function buildTimeline(numTrials) {
 
     timeline.push(flashNode);
 
-    // Response Node (all 10 images)
-    const choices = shuffleInPlace([...imagePool]).map(filename => ({
+    // Response Node (3 images)
+    const distractors = imagePool.filter(f => f !== t1Filename && f !== t2Filename);
+    const randomDistractor = chooseRandom(distractors);
+    const choiceFilenames = [t1Filename, t2Filename, randomDistractor];
+    const choices = shuffleInPlace(choiceFilenames).map(filename => ({
       filename,
       src: joinPath(NEUTRAL_DIR, filename)
     }));


### PR DESCRIPTION
Updated the dual image masking logic to present only 3 images for the participant to choose from instead of all 10. Modifies the underlying JavaScript to properly pick exactly two targets and one distractor, updates the quest guess rates for mathematical accuracy, and updates HTML instructions.

---
*PR created automatically by Jules for task [4404467791628653291](https://jules.google.com/task/4404467791628653291) started by @jobellet*