### PR TITLE
Fix audio skipping in Triplet Odd One Out

### DIFF
--- a/experiments/triplet-odd-one-out.html
+++ b/experiments/triplet-odd-one-out.html
@@ -312,6 +312,7 @@
   <script src="https://unpkg.com/jspsych@8.0.0"></script>
   <script src="https://unpkg.com/@jspsych/plugin-html-button-response@2.0.0"></script>
   <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@2.0.0"></script>
+  <script src="https://unpkg.com/@jspsych/plugin-audio-keyboard-response@2.0.0"></script>
   <script src="https://unpkg.com/@jspsych/plugin-call-function@2.0.0"></script>
   <script src="triplet-odd-one-out.js"></script>
 </body>

--- a/experiments/triplet-odd-one-out.js
+++ b/experiments/triplet-odd-one-out.js
@@ -66,47 +66,58 @@ const instructions = {
 
 const trialState = {};
 
-const playAudioNode = {
+const pickSoundsNode = {
   type: jsPsychCallFunction,
-  async: true,
-  func: async (callback) => {
-    const display = jsPsych.getDisplayElement();
-    if (display) {
-      display.innerHTML = `
-        <div class="stage">
-          <div class="trial-progress">Trial ${trialCount + 1}</div>
-          <div class="speaker-icon" role="img" aria-label="speaker">🔊</div>
-          <p class="response-text">Playing sounds...</p>
-        </div>
-      `;
-    }
-
-    const sounds = getRandomSounds(3);
-    trialState.sounds = sounds;
+  func: () => {
+    trialState.sounds = getRandomSounds(3);
     trialState.soundStartTime = performance.now();
-
-    const playSound = (path) => {
-      return new Promise((resolve, reject) => {
-        const audio = new Audio(`../assets/${path}`);
-        audio.onended = resolve;
-        audio.onerror = reject;
-        audio.play().catch(reject);
-      });
-    };
-
-    try {
-      await playSound(sounds[0]);
-      await new Promise(r => setTimeout(r, 500));
-      await playSound(sounds[1]);
-      await new Promise(r => setTimeout(r, 500));
-      await playSound(sounds[2]);
-
-      callback();
-    } catch (e) {
-      console.error("Error playing audio", e);
-      callback();
-    }
   }
+};
+
+const playSoundPrompt = () => `
+  <div class="stage">
+    <div class="trial-progress">Trial ${trialCount + 1}</div>
+    <div class="speaker-icon" role="img" aria-label="speaker">🔊</div>
+    <p class="response-text">Playing sounds...</p>
+  </div>
+`;
+
+const playSound1 = {
+  type: jsPsychAudioKeyboardResponse,
+  stimulus: () => `../assets/${trialState.sounds[0]}`,
+  choices: "NO_KEYS",
+  trial_ends_after_audio: true,
+  prompt: playSoundPrompt
+};
+
+const isi1 = {
+  type: jsPsychHtmlKeyboardResponse,
+  stimulus: playSoundPrompt,
+  choices: "NO_KEYS",
+  trial_duration: 500
+};
+
+const playSound2 = {
+  type: jsPsychAudioKeyboardResponse,
+  stimulus: () => `../assets/${trialState.sounds[1]}`,
+  choices: "NO_KEYS",
+  trial_ends_after_audio: true,
+  prompt: playSoundPrompt
+};
+
+const isi2 = {
+  type: jsPsychHtmlKeyboardResponse,
+  stimulus: playSoundPrompt,
+  choices: "NO_KEYS",
+  trial_duration: 500
+};
+
+const playSound3 = {
+  type: jsPsychAudioKeyboardResponse,
+  stimulus: () => `../assets/${trialState.sounds[2]}`,
+  choices: "NO_KEYS",
+  trial_ends_after_audio: true,
+  prompt: playSoundPrompt
 };
 
 const responseNode = {
@@ -129,7 +140,7 @@ const responseNode = {
 };
 
 const trialSequence = {
-  timeline: [playAudioNode, responseNode]
+  timeline: [pickSoundsNode, playSound1, isi1, playSound2, isi2, playSound3, responseNode]
 };
 
 const experimentLoop = {


### PR DESCRIPTION
The triplet odd one out experiment failed to play audio and immediately skipped to the judgment screen due to manual Audio API usages throwing unchecked promises. This PR implements a jsPsych native timeline.

---
*PR created automatically by Jules for task [13123425467317568660](https://jules.google.com/task/13123425467317568660) started by @jobellet*