### PR TITLE
feat: add continuous sound recognition experiment

### DIFF
--- a/experiments/continuous-sound-recognition.html
+++ b/experiments/continuous-sound-recognition.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Continuous Sound Recognition</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://unpkg.com/jspsych@8.0.0/css/jspsych.css" />
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+      --bg: radial-gradient(circle at top, #0f172a 0%, #111827 60%, #020617 100%);
+      --card-bg: rgba(15, 23, 42, 0.9);
+      --accent: #38bdf8;
+      --stage-size: min(68vw, 68vh);
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--bg);
+      color: #e2e8f0;
+      padding: clamp(16px, 4vw, 48px);
+    }
+
+    #pre-experiment {
+      position: fixed;
+      inset: 0;
+      background: radial-gradient(circle at top, rgba(15, 23, 42, 0.96) 0%, rgba(2, 6, 23, 0.94) 100%);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: clamp(24px, 6vw, 72px);
+      z-index: 10;
+      transition: opacity 220ms ease;
+    }
+
+    #pre-experiment.hidden {
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    .session-card {
+      width: min(92vw, 720px);
+      background: rgba(15, 23, 42, 0.85);
+      border-radius: clamp(24px, 4vw, 36px);
+      box-shadow: 0 30px 70px rgba(2, 6, 23, 0.6);
+      padding: clamp(28px, 6vw, 56px);
+      display: flex;
+      flex-direction: column;
+      gap: clamp(16px, 4vw, 28px);
+    }
+
+    .session-card h1 {
+      margin: 0;
+      font-size: clamp(1.6rem, 4vw, 2.15rem);
+    }
+
+    .session-card p {
+      margin: 0;
+      color: rgba(203, 213, 225, 0.92);
+      line-height: 1.5;
+    }
+
+    .session-status {
+      margin: 0;
+      font-size: clamp(0.95rem, 2.6vw, 1.05rem);
+      color: rgba(148, 163, 184, 0.88);
+    }
+
+    .session-status[data-state='error'] {
+      color: #fca5a5;
+    }
+
+    .session-status[data-state='warning'] {
+      color: #facc15;
+    }
+
+    .session-status strong {
+      color: #f8fafc;
+    }
+
+    .session-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+
+    .session-actions .jspsych-btn:disabled {
+      opacity: 0.55;
+      cursor: not-allowed;
+    }
+
+    #jspsych-target {
+      width: min(96vw, 860px);
+      background: rgba(15, 23, 42, 0.82);
+      backdrop-filter: blur(18px);
+      border-radius: 32px;
+      box-shadow: 0 24px 60px rgba(2, 6, 23, 0.55);
+      padding: clamp(24px, 5vw, 56px);
+      position: relative;
+    }
+
+    .jspsych-display-element {
+      font-size: clamp(18px, 3vw, 22px);
+      line-height: 1.7;
+    }
+
+    .jspsych-btn {
+      font-size: clamp(1rem, 2.6vw, 1.15rem);
+      padding: clamp(12px, 3vw, 16px) clamp(24px, 5vw, 36px);
+      border-radius: 999px;
+      border: none;
+      background: linear-gradient(135deg, var(--accent), #2563eb);
+      color: white;
+      font-weight: 600;
+      box-shadow: inset 0 -2px 0 rgba(15, 23, 42, 0.25);
+      transition: transform 160ms ease, box-shadow 160ms ease;
+      cursor: pointer;
+    }
+
+    .jspsych-btn:active {
+      transform: translateY(2px);
+      box-shadow: inset 0 2px 0 rgba(15, 23, 42, 0.35);
+    }
+
+    .stage {
+      position: relative;
+      width: 100%;
+      height: var(--stage-size);
+      margin: 0 auto;
+      background: radial-gradient(circle at top, rgba(15, 23, 42, 0.95) 0%, rgba(2, 6, 23, 0.88) 80%);
+      border-radius: clamp(24px, 6vw, 36px);
+      box-shadow: inset 0 0 0 2px rgba(148, 163, 184, 0.08), 0 24px 60px rgba(2, 6, 23, 0.6);
+      overflow: hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-direction: column;
+      text-align: center;
+    }
+
+    .speaker-icon {
+      font-size: clamp(64px, 12vw, 120px);
+      margin-bottom: 20px;
+    }
+
+    .response-text {
+      font-size: clamp(18px, 3.2vw, 24px);
+      color: rgba(226, 232, 240, 0.94);
+      text-align: center;
+      padding: 24px;
+    }
+
+    .trial-progress {
+      font-size: clamp(14px, 2.5vw, 16px);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: rgba(148, 163, 184, 0.8);
+      text-align: center;
+      margin-bottom: 16px;
+      position: absolute;
+      top: 20px;
+      left: 0;
+      width: 100%;
+    }
+
+    .control-button {
+      position: fixed;
+      z-index: 30;
+      border: none;
+      font-family: inherit;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      border-radius: clamp(18px, 4vw, 26px);
+      box-shadow: 0 18px 40px rgba(2, 6, 23, 0.45);
+      cursor: pointer;
+      transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
+      pointer-events: auto;
+      touch-action: manipulation;
+      user-select: none;
+    }
+
+    .control-button:active {
+      transform: translateY(2px);
+      box-shadow: 0 8px 24px rgba(2, 6, 23, 0.35);
+    }
+
+    #stop-experiment {
+      top: clamp(24px, 5vw, 48px);
+      left: clamp(24px, 5vw, 48px);
+      padding: clamp(16px, 4vw, 20px) clamp(28px, 6vw, 42px);
+      font-size: clamp(0.95rem, 2.8vw, 1.2rem);
+      background: rgba(248, 250, 252, 0.9);
+      color: #0f172a;
+    }
+
+    @media (max-width: 600px) {
+      #pre-experiment {
+        padding: 20px;
+      }
+
+      #jspsych-target {
+        padding: clamp(20px, 6vw, 40px);
+      }
+
+      .stage {
+        border-radius: clamp(20px, 8vw, 32px);
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="pre-experiment">
+    <div class="session-card">
+      <h1>Continuous Sound Recognition</h1>
+      <p>
+        You will hear a series of random sounds presented one after another with variable silent gaps.<br><br>
+        If a sound is <strong>exactly the same</strong> as the one immediately preceding it, click the <strong>"SAME"</strong> button or press the <strong>Spacebar</strong> as quickly as possible.<br><br>
+        If the sound is different from the previous one, do not press anything.
+      </p>
+      <p id="session-status" class="session-status" data-state="info"></p>
+      <div class="session-actions">
+        <button id="start-experiment" class="jspsych-btn">Start Experiment</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="jspsych-target"></div>
+  <button id="stop-experiment" class="control-button" hidden>Stop &amp; Download</button>
+
+  <script src="https://unpkg.com/jspsych@8.0.0"></script>
+  <script src="https://unpkg.com/@jspsych/plugin-html-button-response@2.0.0"></script>
+  <script src="https://unpkg.com/@jspsych/plugin-call-function@2.0.0"></script>
+  <script src="https://unpkg.com/jsquest-plus@2.1.0/dist/jsQuestPlus.js"></script>
+  <script type="module" src="continuous-sound-recognition.js"></script>
+</body>
+</html>

--- a/experiments/continuous-sound-recognition.js
+++ b/experiments/continuous-sound-recognition.js
@@ -1,0 +1,391 @@
+import NoGoCtrl from './noGoController.js';
+import { secureRandom } from '../shared-resources/utils/random.js';
+import { formatTimestampForFilename } from '../shared-resources/utils/date.js';
+import { downloadBlob } from '../shared-resources/utils/downloadBlob.js';
+
+// jsQuestPlus is loaded globally from unpkg
+// jsPsych is loaded globally from unpkg
+
+let jsPsych;
+let audioContext = null;
+let soundManifest = [];
+let audioBuffers = {}; // cache decoded audio buffers
+
+// DOM Elements
+const preExperimentOverlay = document.getElementById('pre-experiment');
+const startButton = document.getElementById('start-experiment');
+const statusEl = document.getElementById('session-status');
+const stopExperimentButton = document.getElementById('stop-experiment');
+
+// State
+let sessionRunning = false;
+let sessionFinalized = false;
+let trialCount = 0;
+let questEngine = null;
+
+const trialState = {
+  previousSound: null,
+  currentSound: null,
+  isGo: false, // Go = SAME (target), No-Go = DIFFERENT (distractor)
+  currentVolume: 1.0,
+  isi: 1000,
+  responded: false,
+  rt: null
+};
+
+function setStatus(message, state = 'info') {
+  if (!statusEl) return;
+  statusEl.textContent = message;
+  statusEl.dataset.state = state;
+}
+
+// Load manifest
+async function loadManifest() {
+  try {
+    const response = await fetch('../assets/sound-manifest.json');
+    soundManifest = await response.json();
+    setStatus(`Loaded ${soundManifest.length} sounds. Ready to start.`, 'info');
+  } catch (e) {
+    setStatus('Failed to load sound manifest.', 'error');
+  }
+}
+
+// Ensure Audio Context
+function ensureAudioContext() {
+  if (!audioContext) {
+    audioContext = new (window.AudioContext || window.webkitAudioContext)();
+  }
+  if (audioContext.state === 'suspended') {
+    audioContext.resume();
+  }
+}
+
+// Decode Audio Data
+async function getAudioBuffer(path) {
+  if (audioBuffers[path]) return audioBuffers[path];
+
+  try {
+    const response = await fetch(`../assets/${path}`);
+    const arrayBuffer = await response.arrayBuffer();
+    ensureAudioContext();
+    const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+    audioBuffers[path] = audioBuffer;
+    return audioBuffer;
+  } catch (e) {
+    console.error(`Failed to load or decode audio: ${path}`, e);
+    return null;
+  }
+}
+
+// Setup jsQuestPlus
+function initQuest() {
+  const amplitudes = [];
+  for (let i = 0.01; i <= 1.0; i += 0.01) {
+    amplitudes.push(Math.round(i * 100) / 100);
+  }
+
+  questEngine = new jsQuestPlus({
+    psych_func: [
+      (stim, alpha, beta, guess, lapse) => 1 - (guess + (1 - guess - lapse) * (1 - Math.exp(-Math.pow(stim / alpha, beta)))),
+      (stim, alpha, beta, guess, lapse) => guess + (1 - guess - lapse) * (1 - Math.exp(-Math.pow(stim / alpha, beta)))
+    ],
+    stim_samples: [amplitudes],
+    psych_samples: [
+      amplitudes,
+      [2, 3, 4, 5], // beta
+      [0.05], // guess rate (chance of FA)
+      [0.01, 0.02] // lapse
+    ]
+  });
+}
+
+function suggestVolume() {
+  if (!questEngine) return 1.0;
+  try {
+    const est = questEngine.getEstimates('mode');
+    if (Array.isArray(est) && est.length >= 4) {
+      const target = 0.75;
+      const [alpha, beta, guess, lapse] = est;
+      let best = 1.0;
+      let bestDiff = Infinity;
+
+      for (let v = 0.01; v <= 1.0; v += 0.01) {
+        const p = guess + (1 - guess - lapse) * (1 - Math.exp(-Math.pow(v / alpha, beta)));
+        const d = Math.abs(p - target);
+        if (d < bestDiff) {
+          bestDiff = d;
+          best = v;
+        }
+      }
+      return Math.max(0.01, best);
+    }
+  } catch (e) {
+    console.warn("Quest suggestVolume error", e);
+  }
+
+  // Fallback to questEngine's current suggestion if we couldn't calculate
+  try {
+    return questEngine.getStimParams();
+  } catch (e) {
+    return 1.0;
+  }
+}
+
+// Node: Prepare trial
+const prepareTrialNode = {
+  type: jsPsychCallFunction,
+  async: true,
+  func: async (done) => {
+    ensureAudioContext();
+
+    // Gap: 1 to 5 seconds
+    trialState.isi = 1000 + secureRandom() * 4000;
+
+    if (trialCount === 0) {
+      // First trial: Random sound, volume 1.0
+      trialState.isGo = false;
+      trialState.currentVolume = 1.0;
+      trialState.currentSound = soundManifest[Math.floor(secureRandom() * soundManifest.length)];
+    } else {
+      // Is this a Go (SAME) or No-Go (DIFFERENT) trial?
+      // NoGoCtrl schedules No-Go trials. In our context, No-Go = DIFFERENT.
+      // So decideNoGo() returning true means we should present a DIFFERENT sound.
+
+      const isDifferent = NoGoCtrl.decideNoGo();
+
+      if (isDifferent) {
+        // No-Go: DIFFERENT sound, Volume 1.0
+        trialState.isGo = false;
+        trialState.currentVolume = 1.0;
+
+        let newSound;
+        do {
+          newSound = soundManifest[Math.floor(secureRandom() * soundManifest.length)];
+        } while (newSound === trialState.previousSound);
+        trialState.currentSound = newSound;
+
+      } else {
+        // Go: SAME sound, Quest+ volume
+        trialState.isGo = true;
+        trialState.currentVolume = suggestVolume();
+        trialState.currentSound = trialState.previousSound;
+      }
+    }
+
+    trialState.responded = false;
+    trialState.rt = null;
+
+    // Decode audio
+    await getAudioBuffer(trialState.currentSound);
+
+    // Wait for ISI
+    setTimeout(() => {
+        done();
+    }, trialState.isi);
+  }
+};
+
+// Play audio and show response button
+const playSoundAndResponseNode = {
+  type: jsPsychHtmlButtonResponse,
+  stimulus: () => `
+    <div class="stage">
+      <div class="trial-progress">Trial ${trialCount + 1}</div>
+      <div class="speaker-icon" role="img" aria-label="speaker">🔊</div>
+      <p class="response-text">Press Spacebar or click SAME if this sound matches the previous one.</p>
+    </div>
+  `,
+  choices: ['SAME'],
+  trial_duration: 2000,
+  response_ends_trial: false, // Need to let sound play, wait up to 2 seconds
+  on_start: (trial) => {
+    // Add keydown listener
+    const keyListener = (e) => {
+      if (e.code === 'Space' && !trialState.responded) {
+        e.preventDefault();
+        trialState.responded = true;
+        trialState.rt = performance.now() - trialState.soundStartTime;
+        // Optionally update UI to show response registered
+        const btn = document.querySelector('.jspsych-btn');
+        if (btn) btn.style.background = '#10b981'; // Green
+      }
+    };
+    document.addEventListener('keydown', keyListener);
+    trialState.keyListener = keyListener;
+  },
+  on_load: () => {
+    // Play sound via Web Audio API with Gain
+    ensureAudioContext();
+    const source = audioContext.createBufferSource();
+    source.buffer = audioBuffers[trialState.currentSound];
+
+    const gainNode = audioContext.createGain();
+    gainNode.gain.value = trialState.currentVolume;
+
+    source.connect(gainNode);
+    gainNode.connect(audioContext.destination);
+
+    trialState.soundStartTime = performance.now();
+    source.start();
+    trialState.currentSource = source;
+
+    // Handle button click manually since response_ends_trial is false
+    const btn = document.querySelector('.jspsych-btn');
+    if (btn) {
+      btn.addEventListener('click', () => {
+        if (!trialState.responded) {
+          trialState.responded = true;
+          trialState.rt = performance.now() - trialState.soundStartTime;
+          btn.style.background = '#10b981';
+        }
+      });
+    }
+  },
+  on_finish: (data) => {
+    document.removeEventListener('keydown', trialState.keyListener);
+
+    if (trialState.currentSource) {
+      try {
+        trialState.currentSource.stop();
+      } catch (e) {}
+    }
+
+    // Determine response (true if button clicked or space pressed within 2s)
+    const responded = trialState.responded;
+
+    // Update NoGoCtrl (for DIFFERENT sounds)
+    // NoGoCtrl expects { isNoGo, responded }
+    NoGoCtrl.onTrialEnd({ isNoGo: !trialState.isGo, responded });
+
+    // Update Quest+ (for SAME sounds)
+    if (trialState.isGo && questEngine) {
+      try {
+        questEngine.update(trialState.currentVolume, responded ? 1 : 0);
+      } catch (e) {
+        console.warn('Quest update skipped', e);
+      }
+    }
+
+    // Save data
+    data.trial_index = trialCount;
+    data.sound = trialState.currentSound;
+    data.previous_sound = trialState.previousSound;
+    data.is_go = trialState.isGo;
+    data.is_same = trialState.isGo;
+    data.volume = trialState.currentVolume;
+    data.isi = trialState.isi;
+    data.responded = responded;
+    data.rt = trialState.rt;
+    data.correct = trialState.isGo ? responded : !responded;
+
+    // Prepare for next
+    trialState.previousSound = trialState.currentSound;
+    trialCount++;
+  }
+};
+
+const trialSequence = {
+  timeline: [prepareTrialNode, playSoundAndResponseNode]
+};
+
+const experimentLoop = {
+  timeline: [trialSequence],
+  loop_function: () => {
+    return sessionRunning; // Continue loop only if session is running
+  }
+};
+
+// ===========================
+// Application Flow
+// ===========================
+
+function finalizeSession(reason = 'complete') {
+  if (sessionFinalized) return;
+  sessionFinalized = true;
+  sessionRunning = false;
+
+  if (jsPsych) {
+    jsPsych.abortExperiment();
+  }
+
+  if (stopExperimentButton) {
+    stopExperimentButton.hidden = true;
+  }
+
+  if (audioContext) {
+    audioContext.close();
+    audioContext = null;
+  }
+
+  const newValues = jsPsych.data.get().values();
+  const timestamp = formatTimestampForFilename(new Date());
+
+  if (newValues.length) {
+    downloadBlob(`continuous-sound-recognition-${timestamp}.csv`, jsPsych.data.get().csv(), 'text/csv');
+  }
+
+  setStatus(
+    newValues.length
+      ? `${reason === 'stopped' ? 'Session stopped early.' : 'Session complete.'} Downloaded ${newValues.length} new trials.`
+      : `Session ended. No new trials were recorded.`,
+    'info'
+  );
+
+  if (preExperimentOverlay) {
+    preExperimentOverlay.classList.remove('hidden');
+  }
+
+  // Update button text
+  startButton.textContent = 'Run another block';
+
+  jsPsych.getDisplayElement().innerHTML = '';
+}
+
+function handleStartClick() {
+  if (sessionRunning) return;
+  if (soundManifest.length === 0) {
+      setStatus('No sounds loaded.', 'error');
+      return;
+  }
+
+  sessionRunning = true;
+  sessionFinalized = false;
+  trialCount = 0;
+  trialState.previousSound = null;
+
+  initQuest();
+
+  if (preExperimentOverlay) {
+    preExperimentOverlay.classList.add('hidden');
+  }
+
+  if (stopExperimentButton) {
+    stopExperimentButton.hidden = false;
+  }
+
+  jsPsych = initJsPsych({
+    display_element: 'jspsych-target',
+    show_progress_bar: false,
+    on_finish: () => {
+      if (!sessionFinalized) finalizeSession('complete');
+    }
+  });
+
+  jsPsych.data.reset(true);
+
+  const timeline = [];
+  timeline.push(experimentLoop);
+
+  jsPsych.run(timeline);
+}
+
+// Event Listeners
+if (startButton) startButton.addEventListener('click', handleStartClick);
+if (stopExperimentButton) {
+  stopExperimentButton.addEventListener('click', () => {
+    finalizeSession('stopped');
+  });
+}
+
+// Initialize
+loadManifest();


### PR DESCRIPTION
This PR adds the "Continuous Sound Recognition" experiment requested by the user.

- Uses `jsPsych` and Web Audio API for playback.
- Variable ISI gaps of 1 to 5 seconds.
- Uses `NoGoCtrl` to adapt the probability of a sound *not* repeating, controlling the false alarm rate under 5%.
- Uses `jsQuestPlus` to staircase the amplitude (volume) of repeating sounds, targeting 75% detectability.
- Added a card to `index.html` linking to the new experiment.

---
*PR created automatically by Jules for task [11213368258383455935](https://jules.google.com/task/11213368258383455935) started by @jobellet*