### PR TITLE
🧹 Fix false positive dead code warning in noGoController.js

### DIFF
--- a/experiments/noGoController.js
+++ b/experiments/noGoController.js
@@ -31,7 +31,7 @@ const NoGoCtrl = (() => {
   }
 
   // Estimate the false-alarm rate.  Before any No-Go trials occur we just
-  // return the controller's target value.
+  // output the controller's target value.
   function estFA() {
     return faEma === null ? cfg.pTargetFA : faEma;
   }


### PR DESCRIPTION
🎯 **What:** The static analyzer was incorrectly flagging a comment (`// return the controller's target value.`) as a commented-out `return` statement (dead code).
💡 **Why:** By rewording "return" to "output" in the comment, we resolve the false positive warning and prevent it from distracting developers, improving the codebase's overall code health metric.
✅ **Verification:** Ran `node --test` suite successfully. Validated locally via code review that no semantic or logical changes were introduced.
✨ **Result:** The code health issue is completely resolved without altering functionality.

---
*PR created automatically by Jules for task [9602404934655149366](https://jules.google.com/task/9602404934655149366) started by @jobellet*